### PR TITLE
Preproc fixes

### DIFF
--- a/aopy/data.py
+++ b/aopy/data.py
@@ -293,7 +293,7 @@ def get_ecube_data_sources(data_dir):
     dat = Dataset(data_dir)
     return dat.listsources()
 
-def _process_channels(data_dir, data_source, channels, n_samples, dtype=None, data_out=None, **dataset_kwargs):
+def _process_channels(data_dir, data_source, channels, n_samples, dtype=None, data_out=None, debug=False, **dataset_kwargs):
     '''
     Reads data from an ecube data source by channel until the number of samples requested 
     has been loaded. If a processing function is supplied, it will be applied to 
@@ -316,7 +316,7 @@ def _process_channels(data_dir, data_source, channels, n_samples, dtype=None, da
 
     dat = Dataset(data_dir, **dataset_kwargs)
     dat.selectsource(data_source)
-    chunk = dat.emitchunk(startat=0, debug=True)
+    chunk = dat.emitchunk(startat=0, debug=debug)
     datastream = ChunkedStream(chunkemitter=chunk)
 
     idx_samples = 0 # keeps track of the number of samples already read/written

--- a/aopy/preproc.py
+++ b/aopy/preproc.py
@@ -902,7 +902,7 @@ def _parse_bmi3d_v1(data_dir, files):
         })    
     return data_dict, metadata_dict
 
-def _prepare_bmi3d_v0(data, metadata, max_missing_markers=10):
+def _prepare_bmi3d_v0(data, metadata):
     '''
     Organizes the bmi3d data and metadata and computes some automatic conversions
 
@@ -1035,6 +1035,7 @@ def _prepare_bmi3d_v0(data, metadata, max_missing_markers=10):
         corrected_clock = rfn.append_fields(corrected_clock, 'timestamp_sync', timestamp_sync, dtypes='f8')
 
     measure_search_radius = 0.01
+    max_missing_markers = len(corrected_clock) * 0.05 # maximum 5 percent missing
     metadata['has_measured_timestamps'] = False
     if 'measure_clock_online' in data and len(data['measure_clock_online']) > 0:
         # Find the timestamps for each cycle of bmi3d's state machine from all the clock sources
@@ -1052,7 +1053,7 @@ def _prepare_bmi3d_v0(data, metadata, max_missing_markers=10):
             metadata['has_measured_timestamps'] = True
             corrected_clock['timestamp'] = corrected_timestamps
         else:
-            print("Something has gone wrong with the digital screen sensor. Ignoring")
+            print(f"Digital screen sensor missing too many markers ({n_consecutive_missing_markers}/{max_missing_markers}). Ignoring")
 
     if 'measure_clock_offline' in data and len(data['measure_clock_offline']) > 0:
         timestamp_measure_offline = get_measured_frame_timestamps(
@@ -1069,7 +1070,7 @@ def _prepare_bmi3d_v0(data, metadata, max_missing_markers=10):
             corrected_clock['timestamp'] = corrected_timestamps
             metadata['has_measured_timestamps'] = True
         else:
-            print("Something has gone wrong with the analog screen sensor. Ignoring")
+            print(f"Analog screen sensor missing too many markers ({n_consecutive_missing_markers}/{max_missing_markers}). Ignoring")
 
     # Create a 'trials' table if it doesn't exist
     if not 'bmi3d_trials' in data:

--- a/docs/source/preproc.rst
+++ b/docs/source/preproc.rst
@@ -89,6 +89,8 @@ Information needed to reconstruct the structure of the experiment.
      - Time at which the event was received in ecube  
    * - ``timestamp_measure`` (float)
      - Time at which the event was measured to have occurred on the screen
+   * - ``timestamp`` (float)
+     - Default timestamp to make analysis code neater. Preference ``timestamp_measure`` >> ``timestamp_sync`` >> ``timestamp_bmi3d``
 
 
 **task**

--- a/docs/source/preproc.rst
+++ b/docs/source/preproc.rst
@@ -1,5 +1,417 @@
 Preproc:
 ===============
 
+Preprocessed data format
+------------------------
+
+Preprocessed BMI3D data takes the form of an HDF file containing several datasets. Each dataset is labeled as 
+either ``_data`` or ``_metadata`` depending on its source. Datasets with the ``data`` suffix typically contain numpy structured arrays while those denoted ``metadata`` 
+contain simple data types. 
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+   
+   * - Dataset
+     - Contents
+   * - ``exp_data``
+     - The experimental data. It contains all the information about timing, position, state, events, etc. 
+   * - ``exp_metadata``
+     - Metadata explaining the experimental data, e.g. information about the subject, date, and experimental parameters
+   * - ``mocap_data``
+     - Motion capture data
+   * - ``mocap_metadata``
+     - Metadata explaining the motion capture data
+   * - ``broadband``
+     - Unfiltered raw neural data
+   * - ``lfp``
+     - TBD
+   * - ``spike``
+     - TBD
+
+Experimental data
+-----------------
+
+**clock**
+
+[shape: (13132,), type: [('time', '<u8'), ('prev_tick', '<f8'), ('timestamp', '<f8'), ('timestamp_bmi3d', '<f8'), ('timestamp_sync', '<f8'),  ('timestamp_measure_offline', '<f8'),  ('timestamp_measure_online', '<f8')]]
+
+A record of the time at which each cycle in the bmi state machine loop occurred.
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+   
+   * - Field
+     - Contents
+   * - ``time`` (unsigned int)
+     - Integer cycle number
+   * - ``prev_tick`` (float)
+     - How much time elapsed since the previous frame (measured by bmi3d in ms)
+   * - ``timestamp`` (float)
+     - Corrected measured timestamps from the screen sensor preprocessed to fill in missing values
+   * - ``timestamp_bmi3d`` (float)
+     - Uncorrected timestamps from bmi3d
+   * - ``timestamp_sync`` (float)
+     - Uncorrected timestamps sent from bmi3d digital output
+   * - ``timestamp_measure_offline`` (float)
+     - Uncorrected timestamps measured from the screen and digitized offline
+   * - ``timestamp_measure_online`` (float)
+     - Uncorrected timestamps measured from the screen and digitized online
+
+The preprocessed ``timestamp`` field will be most useful for aligning data to things that appear on the screen. However, in some cases 
+there may not be anything appearing on the screen, such as when aligning to laser onset. In these cases, the ``timestamp_sync`` will be
+more accurate and should be applied to events, described below.
+
+**events**
+
+[shape: (223,), type: [('time', '<u8'), ('event', 'S32'), ('data', '<u4'), ('code', 'u1'), ('timestamp', '<f8')]]
+
+Information needed to reconstruct the structure of the experiment.
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+   
+   * - Field
+     - Contents
+   * - ``time`` (unsigned int)
+     - Integer cycle number
+   * - ``event`` (string)
+     - Name of the event
+   * - ``data`` (unsigned int)
+     - The corresponding data, e.g. which target or which trial type
+   * - ``code`` (unsigned int)
+     - Raw event code
+   * - ``timestamp_bmi3d`` (float)
+     - Time at which the event was recorded as sent by bmi3d
+   * - ``timestamp_sync`` (float)
+     - Time at which the event was received in ecube  
+   * - ``timestamp_measure`` (float)
+     - Time at which the event was measured to have occurred on the screen
+
+
+**task**
+
+[shape: (13132,), type: [('cursor', '<f8', (3,)), ('sync_square', '?', (1,)), ('manual_input', '<f8', (3,)), ('trial', '<u4', (1,)), ('plant_visible', '?', (1,))]]
+
+Information about things that change on every cycle of the finite state machine loop.
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+   
+   * - Field
+     - Contents
+   * - ``cursor`` (float, (3,))
+     - (x, z, y) cursor coordinates
+   * - ``sync_square`` (bool)
+     - State of the sync square
+   * - ``manual_input`` (float, (3,))
+     - (x, y, z) input before transformation to screen coordinates (only present if this was a manual input task)
+   * - ``trial`` (unsigned int)
+     - Current trial number as calculated by bmi3d
+   * - ``plant_visible`` (bool)
+     - Whether or not the cursor was visible
+
+
+**trials**
+
+[shape: (56,), type: [('trial', '<u4'), ('index', '<u4'), ('target', '<f8', (3,))]]
+
+List of conditions generated on each trial. Can have multiple indices corresponding to a single trial. 
+Depending on the task, there can be multiple factors listed in this table, but it will always include trial
+number and index.
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+   
+   * - Field
+     - Contents
+   * - ``trial`` (unsigned int)
+     - Trial number
+   * - ``index`` (float)
+     - Generator index
+   * - ``target`` (float, (3,))
+     - Position of the target for this trial (if the task had targets)
+
+
+**state**
+
+[shape: (325,), type: [('msg', 'S256'), ('time', '<u4')]]
+
+State machine log
+     
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+   
+   * - Field
+     - Contents
+   * - ``msg`` (string)
+     - Usually the name of a state transition, but also includes annotations
+   * - ``time`` (unsigned int)
+     - Cycle number on which this message occured
+
+**raw bmi3d data**
+
+There are several other fields with the prefix ``_bmi3d``. These contain raw data saved by bmi3d which has been 
+preprocessed into the format described above. They are there for debugging purposes.
+
+Experimental metadata
+---------------------
+
+The `exp_metadata` dataset contains
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+   
+   * - Field
+     - Contents
+   * - ``background``: (float, (4,))
+     - color of the background
+   * - ``block_number``: (int)
+     - unique ID number for this experiment 
+   * - ``bmi3d_parser``: (int)
+     - parser version number
+   * - ``bmi3d_source``: (string)
+     - hdf filename where the raw bmi3d data came from
+   * - ``bmi3d_start_time``: (float)
+     - timestamp recorded by bmi3d internally when the state machine starts (in ms)
+   * - ``cursor_bounds``: (float, (6,))
+     - (x, -x, z, -z, y, -y) coordinates bounding the cursor (in cm)
+   * - ``cursor_color``: (string)
+     - color of the cursor
+   * - ``cursor_radius``: (float)
+     - radius of the cursor (in cm)
+   * - ``data_files``: (dict)
+     - raw data files used in preprocessing
+   * - ``date``: (string)
+     - when the experiment took place
+   * - ``delay_penalty_time``: (float)
+     - duration of penalty for delay violations
+   * - ``delay_time``: (float)
+     - how long the cursor has to remain inside the target after the hold is satisfied but before the go cue
+   * - ``event_sync_dch``: (int, (8,))
+     - range of digital channels on which events are recorded
+   * - ``event_sync_dict``: (dict)
+     - dictionary of event names and codes used for this experiment
+   * - ``event_sync_max_data``: (int)
+     - maximum value of event codes
+   * - ``event_sync_nidaq_mask``: (int)
+     - mask used to drive the national instruments card
+   * - ``features``: (string, (8,))
+     - ?
+   * - ``fps``: (float)
+     - cycle rate that bmi3d was targeting
+   * - ``fullscreen``: (bool)
+     - whether the fullscreen option was turned on
+   * - ``generator``: (string)
+     - name of the generator used in the experiment
+   * - ``generator_params``: (string)
+     - string containing the parameters used to initialize the generator
+   * - ``has_measured_timestamps``: (bool)
+     - whether the measured_timestamps_online and measured_timestamps_offline fields are available in clock
+   * - ``has_reward_system``: (bool)
+     - whether the reward system was recorded
+   * - ``headstage_channels``: (int, (2,))
+     - range of headstage channels recorded on the ecube
+   * - ``headstage_connector``: (int)
+     - which headstage connector was recorded
+   * - ``hold_penalty_time``: (float)
+     - duration of penalty for leaving the target too soon before the hold time has elapsed
+   * - ``hold_time``: (float)
+     - length of time required to hold inside a target
+   * - ``iod``: (float)
+     - intraocular distance (for 3d displays)
+   * - ``latency_estimate``: (float)
+     - 
+   * - ``latency_measured``: (float)
+     - 
+   * - ``max_attempts``: (int)
+     - number of penalties before moving to the next condition in the sequence
+   * - ``n_consecutive_missing_markers``: (int)
+     - 
+   * - ``n_cycles``: (unsigned int)
+     - number of cycles the bmi3d state machine ran
+   * - ``n_missing_markers``: (int)
+     - 
+   * - ``n_trials``: (int)
+     - number of trials the bmi3d state machine counted
+   * - ``notes``: (string)
+     - notes on this task entry from the bmi3d database
+   * - ``offset``: (int, (3,))
+     - for manual control tasks, the (x, y, z) offset applied to inputs
+   * - ``penalty_sound``: (string)
+     - sound file played for penalties
+   * - ``plant_hide_rate``: (float)
+     - 
+   * - ``plant_type``: (string)
+     - 
+   * - ``plant_visible``: (bool)
+     - whether or not the endpoint is visible to the subject
+   * - ``random_rewards``: (bool)
+     - 
+   * - ``record_headstage``: (bool)
+     - 
+   * - ``report``: (string)
+     - the offline report saved to the bmi3d database
+   * - ``reward_measure_ach``: (int)
+     - analog channel used for measuring the reward system output
+   * - ``reward_sound``: (string)
+     - sound file played during a reward
+   * - ``reward_time``: (float)
+     - duration of the rewards
+   * - ``rig_name``: (string)
+     - name of the rig where the experiment was run
+   * - ``rotation``: (string)
+     - for manual control tasks, the name of the rotation matrix applied to inputs
+   * - ``scale``: (float)
+     - for manual control tasks, the multiplication factor applied to inputs
+   * - ``screen_dist``: (float)
+     - for 3D tasks, the distance the display is located away from the subjects eyes
+   * - ``screen_half_height``: (float)
+     - for tasks with a window, the height of the display divided by 2 (in cm)
+   * - ``screen_measure_ach``: (int)
+     - the analog channel used to measure screen refresh rate
+   * - ``screen_measure_dch``: (int)
+     - the digital channel used to measure screen refresh rate
+   * - ``screen_sync_dch``: (int)
+     - the digital channel used to measure bmi3d's sync clock
+   * - ``screen_sync_nidaq_pin``: (int)
+     - 
+   * - ``sequence``: (string)
+     - the name of the bmi3d sequence used in this task
+   * - ``sequence_params``: (string)
+     - the parameters used to generate the sequence
+   * - ``session_length``: (float)
+     - maximum duration of the session. if 0, then the session can continue until the generator is depleted
+   * - ``show_environment``: (int)
+     - if true, a bounding box is shown in 3D around the workspace where the cursor is allowed to move
+   * - ``source_dir``: (string)
+     - directory where the source files for this preprocessed data were stored
+   * - ``source_files``: (dict)
+     - dictionary of files arranged by system that were used to generate this preprocessed data
+   * - ``starting_pos``: (float (3,))
+     - for cursor tasks, the position where the cursor starts (overridden if position control is used)
+   * - ``subject``: (string)
+     - name of the subject
+   * - ``sw_version``: (string)
+     - git hash of the commit being used to run the experiment
+   * - ``sync_color_off``: (float (4,))
+     - color of the square used for screen sync in the "off" state
+   * - ``sync_color_on``: (float (4,))
+     - color of the square used for screen sync in the "on" state
+   * - ``sync_corner``: (string)
+     - where the square for screen sync is located on the display
+   * - ``sync_protocol``: (dict)
+     - dictionary of events and event codes
+   * - ``sync_protocol_version``: (int)
+     - version to keep track of changes to the sync parameters
+   * - ``sync_pulse_width``: (float)
+     - width of clock and event pulses
+   * - ``sync_size``: (float)
+     - size of the square used for screen sync (in cm)
+   * - ``target_color``: (string)
+     - name of the color for targets
+   * - ``target_radius``: (float)
+     - radius of targets (in cm)
+   * - ``task_name``: (string)
+     - name of the bmi3d task used to run this experiment
+   * - ``timeout_penalty_time``: (float)
+     - duration of timeout penalties (in s)
+   * - ``timeout_time``: (float)
+     - time without entering a target before a timeout penalty is applied (in s)
+   * - ``trials_per_reward``: (float)
+     - how many successful trials are required before a reward is delivered
+   * - ``velocity_control``: (bool)
+     - 
+   * - ``wait_time``: (float)
+     - time between each trial (if autostart is disabled)
+   * - ``window_size``: (int, (2,))
+     - width and height of the window (in cm)
+
+Motion capture data
+-----------------
+
+**optitrack**
+
+[('position', 'f8', (3,)), ('rotation', 'f8', (4,)), ('timestamp', 'f8', (1,)]
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+   
+   * - Field
+     - Contents
+   * - ``position`` (float (3,))
+     - (x, y, z) position samples in time (in m)
+   * - ``rotation`` (float (4,))
+     - (x, y, z, w) rotation samples in time (quaternion)
+   * - ``timestamp`` (float)
+     - time at which each sample was recorded (in ecube reference frame)
+
+
+Motion capture metadata
+-----------------------
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+   
+   * - Field
+     - Contents
+   * - ``source_dir`` (str)
+     - directory where the source files are located
+   * - ``source_files`` (dict)
+     - dictionary of source files organized by system from which this preprocessed data was generated
+   * - ``samplerate`` (float)
+     - sampling rate of the motion capture data
+   * - <other metadata from motive>
+     - see motive documentation          
+            
+
+Examples
+--------
+
+To access the data you can do one of the following
+
+.. code-block:: python
+    
+    clock = aopy.data.load_hdf_data(result_dir, result_filename, 'clock', 'exp_data')
+    
+or
+    
+.. code-block:: python
+    
+    data = aopy.data.load_hdf_group(result_dir, result_filename, 'exp_data')
+    clock = data['clock']  
+
+To access fields inside the individual structured arrays,
+
+.. code-block:: python
+    
+    timestamps = clock['timestamp']
+    first_timestamp = timestamps[0]
+
+Note that you can also access structured arrays by row first, then by column
+
+.. code-block:: python
+
+    first_clock = clock[0]
+    first_timestamp = first_clock['timestamp']
+
+Or at the same time
+
+.. code-block:: python
+
+    first_timestamp = clock['timestamp'][0]
+
+
+API
+---
+
 .. automodule:: aopy.preproc
     :members:

--- a/docs/source/preproc.rst
+++ b/docs/source/preproc.rst
@@ -106,7 +106,7 @@ Information about things that change on every cycle of the finite state machine 
    * - Field
      - Contents
    * - ``cursor`` (float, (3,))
-     - (x, z, y) cursor coordinates
+     - (x, z, y) cursor coordinates (in cm)
    * - ``sync_square`` (bool)
      - State of the sync square
    * - ``manual_input`` (float, (3,))
@@ -229,35 +229,35 @@ The `exp_metadata` dataset contains
    * - ``iod``: (float)
      - intraocular distance (for 3d displays)
    * - ``latency_estimate``: (float)
-     - 
+     - preprocessing statistic of estimated screen latency before correction
    * - ``latency_measured``: (float)
-     - 
+     - preprocessing statistic of measured screen latency
    * - ``max_attempts``: (int)
      - number of penalties before moving to the next condition in the sequence
    * - ``n_consecutive_missing_markers``: (int)
-     - 
+     - preprocessing statistic of consecutive missing frame markers
    * - ``n_cycles``: (unsigned int)
      - number of cycles the bmi3d state machine ran
    * - ``n_missing_markers``: (int)
-     - 
+     - preprocessing statistic of missing frame markers from the screen sensor
    * - ``n_trials``: (int)
      - number of trials the bmi3d state machine counted
    * - ``notes``: (string)
      - notes on this task entry from the bmi3d database
    * - ``offset``: (int, (3,))
-     - for manual control tasks, the (x, y, z) offset applied to inputs
+     - for manual control tasks, the (x, y, z) offset applied to raw inputs (for optitrack, in m)
    * - ``penalty_sound``: (string)
      - sound file played for penalties
    * - ``plant_hide_rate``: (float)
-     - 
+     - rate at which the cursor is hidden?
    * - ``plant_type``: (string)
-     - 
+     - 'cursor' is the only option
    * - ``plant_visible``: (bool)
      - whether or not the endpoint is visible to the subject
    * - ``random_rewards``: (bool)
-     - 
+     - whether reward timing is randomized 
    * - ``record_headstage``: (bool)
-     - 
+     - whether ecube headstage data is recorded by bmi3d 
    * - ``report``: (string)
      - the offline report saved to the bmi3d database
    * - ``reward_measure_ach``: (int)
@@ -269,9 +269,9 @@ The `exp_metadata` dataset contains
    * - ``rig_name``: (string)
      - name of the rig where the experiment was run
    * - ``rotation``: (string)
-     - for manual control tasks, the name of the rotation matrix applied to inputs
+     - for manual control tasks, the name of the rotation matrix applied to raw inputs
    * - ``scale``: (float)
-     - for manual control tasks, the multiplication factor applied to inputs
+     - for manual control tasks, the multiplication factor applied to raw inputs
    * - ``screen_dist``: (float)
      - for 3D tasks, the distance the display is located away from the subjects eyes
    * - ``screen_half_height``: (float)
@@ -283,7 +283,7 @@ The `exp_metadata` dataset contains
    * - ``screen_sync_dch``: (int)
      - the digital channel used to measure bmi3d's sync clock
    * - ``screen_sync_nidaq_pin``: (int)
-     - 
+     - pin used by bmi3d to send clock pulses
    * - ``sequence``: (string)
      - the name of the bmi3d sequence used in this task
    * - ``sequence_params``: (string)
@@ -329,7 +329,7 @@ The `exp_metadata` dataset contains
    * - ``trials_per_reward``: (float)
      - how many successful trials are required before a reward is delivered
    * - ``velocity_control``: (bool)
-     - 
+     - for manual control tasks, whether the cursor is under velocity control (true) or position control (false)
    * - ``wait_time``: (float)
      - time between each trial (if autostart is disabled)
    * - ``window_size``: (int, (2,))

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -51,7 +51,7 @@ Once preprocessed, you can inspect the hdf file using ``aopy.data.get_hdf_conten
         ├── bmi3d_start_time
         └── <raw bmi3d metadata>
 
-Anything with the ``bmi3d_`` prefix is raw bmi3d data. Likewise, the ``sync_`` and ``measure_`` prefixes are raw timing data from the ecube.
+See :doc:`preproc.rst` for more details on the data format. 
 To add mocap and spiking data you would call:
 
 .. code-block:: python

--- a/tests/test_preproc.py
+++ b/tests/test_preproc.py
@@ -136,13 +136,13 @@ class DigitalCalcTests(unittest.TestCase):
         expected_array = np.array([0.1, 0.75, 1.2, np.nan])
         np.testing.assert_allclose(parsed_times, expected_array)
 
-    def test_get_measured_frame_timestamps(self):
+    def test_get_measured_clock_timestamps(self):
         latency_estimate = 0.1
         search_radius = 0.001
         estimated_timestamps = np.arange(10000)/100
         measured_timestamps = estimated_timestamps.copy()*1.00001 + latency_estimate
         measured_timestamps = np.delete(measured_timestamps, [500])
-        uncorrected = get_measured_frame_timestamps(estimated_timestamps, measured_timestamps, latency_estimate, search_radius)
+        uncorrected = get_measured_clock_timestamps(estimated_timestamps, measured_timestamps, latency_estimate, search_radius)
         self.assertEqual(len(uncorrected), len(estimated_timestamps))
         self.assertEqual(np.count_nonzero(np.isnan(uncorrected)), 1)
         self.assertTrue(np.isnan(uncorrected[500]))

--- a/tests/test_preproc.py
+++ b/tests/test_preproc.py
@@ -529,7 +529,6 @@ class TestPrepareExperiment(unittest.TestCase):
     def test_parse_bmi3d(self):
 
         # Test empty
-        files = {}
         self.assertRaises(Exception, lambda: parse_bmi3d(data_dir, files))
 
         def check_required_fields(data, metadata):
@@ -545,6 +544,7 @@ class TestPrepareExperiment(unittest.TestCase):
 
 
         # Test sync version 0
+        files = {}
         files['hdf'] = 'test20210310_08_te1039.hdf'
         data, metadata = parse_bmi3d(data_dir, files)
         check_required_fields(data, metadata)
@@ -557,6 +557,7 @@ class TestPrepareExperiment(unittest.TestCase):
         # Test sync version 2
 
         # Test sync version 3 
+        files = {}
         files['hdf'] = 'beig20210407_01_te1315.hdf'
         data, metadata = parse_bmi3d(data_dir, files) # without ecube data
         check_required_fields(data, metadata)
@@ -569,8 +570,10 @@ class TestPrepareExperiment(unittest.TestCase):
         self.assertIn('measure_clock_offline', data)
         self.assertEqual(len(data['measure_clock_offline']['timestamp']), 1054)
         self.assertEqual(len(data['measure_clock_online']['timestamp']), 1015)
+        self.assertTrue(metadata['has_measured_timestamps'])
         
         # Test sync version 4
+        files = {}
         files['hdf'] = 'beig20210614_07_te1825.hdf'
         data, metadata = parse_bmi3d(data_dir, files) # without ecube data
         check_required_fields(data, metadata)
@@ -583,6 +586,7 @@ class TestPrepareExperiment(unittest.TestCase):
         self.assertIn('measure_clock_offline', data)
         self.assertEqual(len(data['measure_clock_offline']['timestamp']), 1758)
         self.assertEqual(len(data['measure_clock_online']), 1682)
+        self.assertTrue(metadata['has_measured_timestamps'])
         self.assertEqual(len(data['clock']['timestamp']), 1830)
         self.assertEqual(len(data['task']), 1830)
 

--- a/tests/test_preproc.py
+++ b/tests/test_preproc.py
@@ -142,11 +142,16 @@ class DigitalCalcTests(unittest.TestCase):
         estimated_timestamps = np.arange(10000)/100
         measured_timestamps = estimated_timestamps.copy()*1.00001 + latency_estimate
         measured_timestamps = np.delete(measured_timestamps, [500])
-        corrected, uncorrected = get_measured_frame_timestamps(estimated_timestamps, measured_timestamps, latency_estimate, search_radius)
-        self.assertEqual(len(corrected), len(estimated_timestamps))
-        self.assertEqual(corrected[500], corrected[501])
-        self.assertEqual(len(uncorrected), len(corrected))
+        uncorrected = get_measured_frame_timestamps(estimated_timestamps, measured_timestamps, latency_estimate, search_radius)
+        self.assertEqual(len(uncorrected), len(estimated_timestamps))
         self.assertEqual(np.count_nonzero(np.isnan(uncorrected)), 1)
+        self.assertTrue(np.isnan(uncorrected[500]))
+
+    def test_fill_missing_timestamps(self):
+        uncorrected_timestamps = [0.01, 0.08, np.nan, np.nan, 0.25, np.nan, 0.38]
+        expected = [0.01, 0.08, 0.25, 0.25, 0.25, 0.38, 0.38]
+        filled = fill_missing_timestamps(uncorrected_timestamps)
+        self.assertCountEqual(expected, filled)
 
 event_log_events_in_str = [
             ('wait', 0.),


### PR DESCRIPTION
Fixed the versioning to allow newer versions to be preprocessed with old code

Change the structure of `clock` and `events` to include different versions of timing:

- bmi3d's internal timing 
- sync timing from bmi3d to ecube
- measured timing of the screen

Added documentation for the preprocessed data structures