### PR TITLE
fix_trial_align_data

### DIFF
--- a/aopy/preproc.py
+++ b/aopy/preproc.py
@@ -513,10 +513,10 @@ def trial_align_data(data, trigger_times, time_before, time_after, samplerate):
 
     Args:
         data (nt, nch): arbitrary data, can be multidimensional
-        trigger_times (ntrial): start time of each trial
-        time_before (float): amount of time to include before the start of each trial
-        time_after (float): time to include after the start of each trial
-        samplerate (int): sampling rate of data
+        trigger_times (ntrial): start time of each trial [s]
+        time_before (float): amount of time [s] to include before the start of each trial
+        time_after (float): time [s] to include after the start of each trial
+        samplerate (int): sampling rate of data [samples/s]
     
     Returns:
         (ntrial, nt, nch): trial aligned data
@@ -527,7 +527,11 @@ def trial_align_data(data, trigger_times, time_before, time_after, samplerate):
     if data.ndim == 1:
         data.shape = (data.shape[0], 1)
     trial_aligned = np.zeros((len(trigger_times), n_samples, *data.shape[1:]))
-    for t in range(len(trigger_times)):
+
+    # Don't look at trigger times that are after the end of the data
+    max_trigger_time = (data.shape[0]/samplerate) - time_after
+    last_trigger_idx = np.where(trigger_times < max_trigger_time)[0][-1]
+    for t in range(last_trigger_idx+1):
         t0 = trigger_times[t] - time_before
         if np.isnan(t0):
             continue

--- a/aopy/preproc.py
+++ b/aopy/preproc.py
@@ -509,7 +509,8 @@ def trial_align_events(aligned_events, aligned_times, event_to_align):
 
 def trial_align_data(data, trigger_times, time_before, time_after, samplerate):
     '''
-    Transform data into chunks of data triggered by trial start times
+    Transform data into chunks of data triggered by trial start times. If trigger_times is too long
+    relative to 'data/samplerate', only the triggers that correspond to data will be returned.
 
     Args:
         data (nt, nch): arbitrary data, can be multidimensional

--- a/tests/test_preproc.py
+++ b/tests/test_preproc.py
@@ -436,12 +436,18 @@ class EventFilterTests(unittest.TestCase):
         time_after = 10
         trigger_times = np.array([5, 55])
         trial_aligned = trial_align_data(data, trigger_times, time_before, time_after, samplerate)
+        print(trial_aligned)
         self.assertEqual(len(trial_aligned), len(trigger_times))
         self.assertTrue(np.allclose(trial_aligned[0], np.arange(5, 15)))
         self.assertTrue(np.allclose(trial_aligned[1], np.arange(55, 65)))
         data = np.ones((100,2))
         trial_aligned = trial_align_data(data, trigger_times, time_before, time_after, samplerate)
         self.assertEqual(trial_aligned.shape, (len(trigger_times), time_after, 2))
+
+        # Test if trigger_times is after the length of data
+        data = np.arange(50)
+        trial_aligned = trial_align_data(data, trigger_times, time_before, time_after, samplerate)
+        np.allclose(trial_aligned, np.arange(5,15))
 
     def test_trial_align_times(self):
         timestamps = np.array([2, 6, 7, 10, 25, 27])


### PR DESCRIPTION
If 'trigger_times' was longer than the input data/samplerate the function broke. Fixed it by only using triggers that are contained within the data. 