### PR TITLE
add automatic testing

### DIFF
--- a/.github/workflow/main.yml
+++ b/.github/workflow/main.yml
@@ -1,0 +1,26 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-cov torch
+          pip install -e .
+      - name: Test with pytest
+        run: |
+          pytest --junitxml=junit/test-results.xml --cov=aopy --cov-report=xml --cov-report=html


### PR DESCRIPTION
not entirely sure this will work, but in theory if we add this "github action" then every time someone makes a push it will run all the tests. then we can add a requirement to pull requests that the tests are passing [see 7. Optionally, enable required status checks.](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule)