### PR TITLE
Make proc_eyetracking return eye data

### DIFF
--- a/aopy/preproc.py
+++ b/aopy/preproc.py
@@ -1479,12 +1479,12 @@ def proc_eyetracking(data_dir, files, result_dir, result_filename, debug=True, o
         result_dir (str): where to store the processed result 
         result_filename (str): what to call the preprocessed filename
         debug (bool, optional): if true, prints additional debug messages
-        overwrite (bool, optional): whether to overwrite existing preprocessed eyetracking data
+        overwrite (bool, optional): whether to recalculated and overwrite existing preprocessed eyetracking data
         **kwargs (dict, optional): keyword arguments to pass to :func:`aopy.preproccalc_eye_calibration()`
 
     Returns:
-        eye_dict (dict, None): all the data pertaining to eye tracking, calibration. None if already processed.
-        eye_metadata (dict, None): metadata for eye tracking. None if already processed.
+        eye_dict (dict): all the data pertaining to eye tracking, calibration
+        eye_metadata (dict): metadata for eye tracking
     '''
     # Check if data already exists
     filepath = os.path.join(result_dir, result_filename)

--- a/aopy/preproc.py
+++ b/aopy/preproc.py
@@ -1491,8 +1491,10 @@ def proc_eyetracking(data_dir, files, result_dir, result_filename, debug=True, o
     if not overwrite and os.path.exists(filepath):
         contents = aodata.get_hdf_dictionary(result_dir, result_filename)
         if "eye_data" in contents and "eye_metadata" in contents:
-            print("File {} already preprocessed, doing nothing.".format(result_filename))
-            return None, None
+            print("Eye data already preprocessed in {}, returning existing data.".format(result_filename))
+            eye_data = aodata.load_hdf_group(result_dir, result_filename, 'eye_data')
+            eye_metadata = aodata.load_hdf_group(result_dir, result_filename, 'eye_metadata')
+            return eye_data, eye_metadata
     
     # Load the preprocessed experimental data
     try:

--- a/aopy/preproc.py
+++ b/aopy/preproc.py
@@ -1468,7 +1468,7 @@ def proc_lfp(data_dir, files, result_dir, result_filename, overwrite=False, batc
         lfp_metadata.update(filter_kwargs)
         aodata.save_hdf(result_dir, result_filename, lfp_metadata, "/lfp_metadata", append=True)
 
-def proc_eyetracking(data_dir, files, result_dir, result_filename, debug=True, overwrite=False, **kwargs):
+def proc_eyetracking(data_dir, files, result_dir, result_filename, debug=True, overwrite=False, save_res=True, **kwargs):
     '''
     Loads eyedata from ecube analog signal and calculates calibration profile using least square fitting.
     Requires that experimental data has already been preprocessed in the same result hdf file.
@@ -1483,7 +1483,8 @@ def proc_eyetracking(data_dir, files, result_dir, result_filename, debug=True, o
         **kwargs (dict, optional): keyword arguments to pass to :func:`aopy.preproccalc_eye_calibration()`
 
     Returns:
-        None
+        eye_dict (dict, None): all the data pertaining to eye tracking, calibration. None if already processed.
+        eye_metadata (dict, None): metadata for eye tracking. None if already processed.
     '''
     # Check if data already exists
     filepath = os.path.join(result_dir, result_filename)
@@ -1491,7 +1492,7 @@ def proc_eyetracking(data_dir, files, result_dir, result_filename, debug=True, o
         contents = aodata.get_hdf_dictionary(result_dir, result_filename)
         if "eye_data" in contents and "eye_metadata" in contents:
             print("File {} already preprocessed, doing nothing.".format(result_filename))
-            return
+            return None, None
     
     # Load the preprocessed experimental data
     try:
@@ -1525,6 +1526,8 @@ def proc_eyetracking(data_dir, files, result_dir, result_filename, debug=True, o
         'cursor_calibration_data': cursor_calibration_data,
         'eye_calibration_data': eye_calibration_data
     }
-    aodata.save_hdf(result_dir, result_filename, eye_dict, "/eye_data", append=True)
-    aodata.save_hdf(result_dir, result_filename, eye_metadata, "/eye_metadata", append=True)
+    if save_res:
+        aodata.save_hdf(result_dir, result_filename, eye_dict, "/eye_data", append=True)
+        aodata.save_hdf(result_dir, result_filename, eye_metadata, "/eye_metadata", append=True)
+    return eye_dict, eye_metadata
 

--- a/aopy/preproc.py
+++ b/aopy/preproc.py
@@ -1480,6 +1480,7 @@ def proc_eyetracking(data_dir, files, result_dir, result_filename, debug=True, o
         result_filename (str): what to call the preprocessed filename
         debug (bool, optional): if true, prints additional debug messages
         overwrite (bool, optional): whether to recalculated and overwrite existing preprocessed eyetracking data
+        save_res (bool, optional): whether to save the calculated eyetracking data
         **kwargs (dict, optional): keyword arguments to pass to :func:`aopy.preproccalc_eye_calibration()`
 
     Returns:

--- a/tests/test_preproc.py
+++ b/tests/test_preproc.py
@@ -616,11 +616,26 @@ class TestPrepareExperiment(unittest.TestCase):
         if os.path.exists(os.path.join(write_dir, result_filename)):
             os.remove(os.path.join(write_dir, result_filename))
         proc_exp(data_dir, files, write_dir, result_filename)
-        proc_eyetracking(data_dir, files, write_dir, result_filename)
+
+        # Test that eye calibration is returned, but results are not saved
+        eye, meta = proc_eyetracking(data_dir, files, write_dir, result_filename, save_res=False)
+        self.assertIsNotNone(eye)
+        self.assertIsNotNone(meta)
+        self.assertRaises(ValueError, lambda: load_hdf_group(write_dir, result_filename, 'eye_data'))
+        self.assertRaises(ValueError, lambda: load_hdf_group(write_dir, result_filename, 'eye_metadata'))
+
+        # Test that eye calibration is saved
+        proc_eyetracking(data_dir, files, write_dir, result_filename, save_res=True)
         eye = load_hdf_group(write_dir, result_filename, 'eye_data')
         meta = load_hdf_group(write_dir, result_filename, 'eye_metadata')
         self.assertIsNotNone(eye)
         self.assertIsNotNone(meta)
+
+        # Test that nothing is returned if no new eye calibration calculated
+        eye, meta = proc_eyetracking(data_dir, files, write_dir, result_filename, save_res=True)
+        self.assertIsNone(eye)
+        self.assertIsNone(meta)
+
 
 
     def preproc_multiple(self):

--- a/tests/test_preproc.py
+++ b/tests/test_preproc.py
@@ -631,11 +631,6 @@ class TestPrepareExperiment(unittest.TestCase):
         self.assertIsNotNone(eye)
         self.assertIsNotNone(meta)
 
-        # Test that nothing is returned if no new eye calibration calculated
-        eye, meta = proc_eyetracking(data_dir, files, write_dir, result_filename, save_res=True)
-        self.assertIsNone(eye)
-        self.assertIsNone(meta)
-
 
 
     def preproc_multiple(self):


### PR DESCRIPTION
proc_eyetracking can now return eye data, add optional bool to control saving the data to filesystem. 
This will allow for quickly recalculating eye tracking data without touching filesystem. 

Testing: ran updated unit test