### PR TITLE
Behavior metrics

### DIFF
--- a/aopy/analysis.py
+++ b/aopy/analysis.py
@@ -1582,12 +1582,12 @@ def time_to_target(event_codes, event_times, target_codes=list(range(81, 89)) , 
             | **reachtime_pertarget (list):** mean reach time per target
             | **trial_id (list):** target index on each trial
     '''
-    event_times = np.array([event_times[iTr] for iTr in range(len(event_times)) if reward_code in event_codes[iTr]])
-    event_codes = np.array([event_codes[iTr] for iTr in range(len(event_times)) if reward_code in event_codes[iTr]])
-    leave_center_idx = np.argwhere(event_codes == go_cue_code)[0, 1]
-    reach_target_idx = np.argwhere(np.isin(event_codes[0], target_codes))[0][0] # using just the first trial to get reach_target_idx
-    reachtime = event_times[:, reach_target_idx] - event_times[:, leave_center_idx]
-    target_dir = event_codes[:,reach_target_idx]
+    tr_T = np.array([event_times[iTr] for iTr in range(len(event_times)) if reward_code in event_codes[iTr]])
+    tr_E = np.array([event_codes[iTr] for iTr in range(len(event_times)) if reward_code in event_codes[iTr]])
+    leave_center_idx = np.argwhere(tr_E == go_cue_code)[0, 1]
+    reach_target_idx = np.argwhere(np.isin(tr_E[0], target_codes))[0][0] # using just the first trial to get reach_target_idx
+    reachtime = tr_T[:, reach_target_idx] - tr_T[:, leave_center_idx]
+    target_dir = tr_E[:,reach_target_idx]
 
     return reachtime, target_dir
 

--- a/aopy/analysis.py
+++ b/aopy/analysis.py
@@ -1564,27 +1564,27 @@ def compute_path_length_per_trial(trajectory):
     return path_length
 
 
-def time_to_target(event_codes, event_times, per_target_stats=False):
+def time_to_target(event_codes, event_times, target_codes = list(range(81, 89)) , go_cue_code= 32 , reward_code = 48, per_target_stats=False):
     '''
     This function calculates reach time to target only on rewarded trials given event codes and event times.
 
     Args:
         event_codes (list) : event codes
-        event_times (list) : event times corresponding to the event codes. These event codes and event times could be the output of preproc.base.get_trial_segments_and_times().
+        event_times (list) : event times corresponding to the event codes. These event codes and event times could be the output of preproc.base.get_trial_segments_and_times()
+        target_codes (list) : list of event codes for cursor entering peripheral target 
+        go_cue_code (int) : event code for go cue 
+        reward_code (int) : event code for reward 
         per_target_stats (bool): optional, use if you want to calculate reach time per target
 
     Returns:
         reach_times (list):
         reach_times_per_target(list of lists) : optional if per_target_stats == True
     '''
-    CURSOR_ENTER_PERIPHERAL_TARGET = list(range(81, 89))
-    CENTER_TARGET_OFF = 32
-    REWARD = 48
-    tr_events = np.array([event_codes[iTr] for iTr in range(len(event_times)) if REWARD in event_codes[iTr]])
-    tr_eventtimes = np.array([event_times[iTr] for iTr in range(len(event_times)) if REWARD in event_codes[iTr]])
-    leave_center_idx = np.argwhere(tr_events == CENTER_TARGET_OFF)[0, 1]
+    tr_events = np.array([event_codes[iTr] for iTr in range(len(event_times)) if reward_code in event_codes[iTr]])
+    tr_eventtimes = np.array([event_times[iTr] for iTr in range(len(event_times)) if reward_code in event_codes[iTr]])
+    leave_center_idx = np.argwhere(tr_events == go_cue_code)[0, 1]
 
-    reach_target_idx = np.argwhere(np.isin(tr_events[0], CURSOR_ENTER_PERIPHERAL_TARGET))[0][0]
+    reach_target_idx = np.argwhere(np.isin(tr_events[0], target_codes))[0][0]
 
     reachtime = tr_eventtimes[:, reach_target_idx] - tr_eventtimes[:, leave_center_idx]
 

--- a/aopy/analysis.py
+++ b/aopy/analysis.py
@@ -1566,11 +1566,11 @@ def compute_path_length_per_trial(trajectory):
 
 def time_to_target(event_codes, event_times, target_codes = list(range(81, 89)) , go_cue_code= 32 , reward_code = 48, per_target_stats=False):
     '''
-    This function calculates reach time to target only on rewarded trials given event codes and event times.
+    This function calculates reach time to target only on rewarded trials given trial aligned event codes and event times See: :func:`aopy.preproc.base.get_trial_segments_and_times` .
 
     Args:
-        event_codes (list) : event codes
-        event_times (list) : event times corresponding to the event codes. These event codes and event times could be the output of preproc.base.get_trial_segments_and_times()
+        event_codes (list) : trial aligned event codes
+        event_times (list) : trial aligned event times corresponding to the event codes. These event codes and event times could be the output of preproc.base.get_trial_segments_and_times()
         target_codes (list) : list of event codes for cursor entering peripheral target 
         go_cue_code (int) : event code for go cue 
         reward_code (int) : event code for reward 

--- a/aopy/analysis.py
+++ b/aopy/analysis.py
@@ -1577,10 +1577,9 @@ def time_to_target(event_codes, event_times, target_codes=list(range(81, 89)) , 
         reward_code (int) : event code for reward
 
     Returns:
-        reach_times (list): time in seconds for each trial between the go cue and the cursor entering peripheral target
-        reach_times_per_target (tuple): optional if per_target_stats == True. Includes:
-            | **reachtime_pertarget (list):** mean reach time per target
-            | **trial_id (list):** target index on each trial
+      tuple: tuple containing:
+        | **reachtime_pertarget (list)**: duration of each segment after filtering
+        | **trial_id (list):** target index on each segment
     '''
     tr_T = np.array([event_times[iTr] for iTr in range(len(event_times)) if reward_code in event_codes[iTr]])
     tr_E = np.array([event_codes[iTr] for iTr in range(len(event_times)) if reward_code in event_codes[iTr]])

--- a/aopy/analysis.py
+++ b/aopy/analysis.py
@@ -1564,7 +1564,7 @@ def compute_path_length_per_trial(trajectory):
     return path_length
 
 
-def time_to_target(event_codes, event_times, target_codes = list(range(81, 89)) , go_cue_code= 32 , reward_code = 48, per_target_stats=False):
+def time_to_target(event_codes, event_times, target_codes=list(range(81, 89)) , go_cue_code=32 , reward_code=48, only_rewarded_trials=True, per_target_stats=False):
     '''
     This function calculates reach time to target only on rewarded trials given trial aligned event codes and event times See: :func:`aopy.preproc.base.get_trial_segments_and_times` .
 
@@ -1574,25 +1574,27 @@ def time_to_target(event_codes, event_times, target_codes = list(range(81, 89)) 
         target_codes (list) : list of event codes for cursor entering peripheral target 
         go_cue_code (int) : event code for go cue 
         reward_code (int) : event code for reward 
-        per_target_stats (bool): optional, use if you want to calculate reach time per target
+        only_rewarded_trials (bool, optional): only include trials with a reward code
+        per_target_stats (bool, optional): use if you want to calculate reach time per target
 
     Returns:
         reach_times (list):
         reach_times_per_target(list of lists) : optional if per_target_stats == True
     '''
-    tr_events = np.array([event_codes[iTr] for iTr in range(len(event_times)) if reward_code in event_codes[iTr]])
-    tr_eventtimes = np.array([event_times[iTr] for iTr in range(len(event_times)) if reward_code in event_codes[iTr]])
-    leave_center_idx = np.argwhere(tr_events == go_cue_code)[0, 1]
-
-    reach_target_idx = np.argwhere(np.isin(tr_events[0], target_codes))[0][0]
-
-    reachtime = tr_eventtimes[:, reach_target_idx] - tr_eventtimes[:, leave_center_idx]
+    event_times = np.array(event_times)
+    event_codes = np.array(event_codes)
+    if only_rewarded_trials:
+        event_times = np.array([event_times[iTr] for iTr in range(len(event_times)) if reward_code in event_codes[iTr]])
+        event_codes = np.array([event_codes[iTr] for iTr in range(len(event_times)) if reward_code in event_codes[iTr]])
+    leave_center_idx = np.argwhere(event_codes == go_cue_code)[0, 1]
+    reach_target_idx = np.argwhere(np.isin(event_codes[0], target_codes))[0][0]
+    reachtime = event_times[:, reach_target_idx] - event_times[:, leave_center_idx]
 
     # mean reach time per target
     if per_target_stats:
         reachtime_pertarget = []
         trial_id = []
-        target_dir = tr_events[:, reach_target_idx]
+        target_dir = event_codes[:, reach_target_idx]
 
         for iT in np.unique(target_dir):
             dir_idx = np.where(target_dir == iT)[0]

--- a/aopy/analysis.py
+++ b/aopy/analysis.py
@@ -1636,7 +1636,7 @@ def calc_segment_duration(events, event_times, start_events, end_events, per_tar
         target_codes = np.array([trial_events[trial_idx][idx] for trial_idx, idx in enumerate(target_idx)])
 
         for target_idx, iT in enumerate(np.unique(target_codes)):
-            per_target_duration.append(np.mean(segment_duration[target_codes == iT]))
+            per_target_duration.append(segment_duration[target_codes == iT])
             per_target_idx.append(target_idx)
         return segment_duration, (per_target_duration, per_target_idx)
     else:

--- a/aopy/analysis.py
+++ b/aopy/analysis.py
@@ -1549,7 +1549,7 @@ def interp_multichannel(x):
 Behavioral metrics 
 '''
 
-def compute_path_length_per_trial(trajectory):
+def compute_path_length_per_trajectory(trajectory):
     '''
     This function calculates the path length by computing the distance from all points for a single trajectory. The input trajectry could be cursor or eye trajectory from a single trial. It returns a single value for path length.
 

--- a/aopy/analysis.py
+++ b/aopy/analysis.py
@@ -242,78 +242,6 @@ def run_tuningcurve_fit(mean_fr, targets, fit_with_nans=False, min_data_pts=3):
     return fit_params, md, pd
 
 '''
-Performance metrics
-'''
-
-def calc_success_percent(events, start_events=[b"TARGET_ON"], end_events=[b"REWARD", b"TRIAL_END"], success_events=b"REWARD", window_size=None):
-    '''
-    A wrapper around get_trial_segments which counts the number of trials with a reward event 
-    and divides by the total number of trials. This function can either calculated the success percent
-    across all trials in the input events, or compute a rolling success percent based on the 'window_size' 
-    input argument.  
-
-    Args:
-        events (nevents): events vector, can be codes, event names, anything to match
-        start_events (int, str, or list, optional): set of start events to match
-        end_events (int, str, or list, optional): set of end events to match
-        success_events (int, str, or list, optional): which events make a trial a successful trial
-        window_size (int, optional): [Untis: number of trials] For computing rolling success perecent. How many trials to include in each window. If None, this functions calculates the success percent across all trials.
-
-    Returns:
-        float or array (nwindow): success percent = number of successful trials out of all trials attempted.
-    '''
-    segments, _ = preproc.get_trial_segments(events, np.arange(len(events)), start_events, end_events)
-    n_trials = len(segments)
-    success_trials = [np.any(np.isin(success_events, trial)) for trial in segments]
-
-    # If requested, calculate success percent across entire input events
-    if window_size is None:
-        n_success = np.count_nonzero(success_trials)  
-        success_percent = n_success / n_trials
-
-    # Otherwise, compute rolling success percent
-    else:
-        filter_array = np.ones(window_size)
-        success_per_window = signal.convolve(success_trials, filter_array, mode='valid', method='direct')
-        success_percent = success_per_window/window_size
-
-    return success_percent
-
-def calc_success_rate(events, event_times, start_events, end_events, success_events, window_size=None):
-    '''
-    Args:
-        events (nevents): events vector, can be codes, event names, anything to match
-        event_times (nevents): time of events in 'events'
-        start_events (int, str, or list, optional): set of start events to match
-        end_events (int, str, or list, optional): set of end events to match
-        success_events (int, str, or list, optional): which events make a trial a successful trial
-        window_size (int, optional): [ntrials] For computing rolling success perecent. How many trials to include in each window. If None, this functions calculates the success percent across all trials.
-
-    Returns:
-        float or array (nwindow): success rate [success/s] = number of successful trials completed per second of time between the start event(s) and end event(s).
-    '''
-    # Get event time information
-    _, times = preproc.get_trial_segments(events, event_times, start_events, end_events)
-    trial_acq_time = times[:,1]-times[:,0]
-    ntrials = times.shape[0]
-    
-    # Get % of successful trials per window 
-    success_perc = calc_success_percent(events, start_events, end_events, success_events, window_size=window_size)
-    
-    # Determine rolling target acquisition time info 
-    if window_size is None:
-        nsuccess = success_perc*ntrials
-        acq_time = np.sum(trial_acq_time)
-
-    else:
-        nsuccess = success_perc*window_size
-        filter_array = np.ones(window_size)
-        acq_time = signal.convolve(trial_acq_time, filter_array, mode='valid', method='direct')
-    
-    success_rate = nsuccess / acq_time
-
-    return success_rate
-'''
 Cell type classification analysis
 '''
 def classify_cells_spike_width(waveform_data, samplerate, std_threshold=3, pca_varthresh=0.75, min_wfs=10):
@@ -1548,6 +1476,76 @@ def interp_multichannel(x):
 '''
 Behavioral metrics 
 '''
+def calc_success_percent(events, start_events=[b"TARGET_ON"], end_events=[b"REWARD", b"TRIAL_END"], success_events=b"REWARD", window_size=None):
+    '''
+    A wrapper around get_trial_segments which counts the number of trials with a reward event 
+    and divides by the total number of trials. This function can either calculated the success percent
+    across all trials in the input events, or compute a rolling success percent based on the 'window_size' 
+    input argument.  
+
+    Args:
+        events (nevents): events vector, can be codes, event names, anything to match
+        start_events (int, str, or list, optional): set of start events to match
+        end_events (int, str, or list, optional): set of end events to match
+        success_events (int, str, or list, optional): which events make a trial a successful trial
+        window_size (int, optional): [Untis: number of trials] For computing rolling success perecent. How many trials to include in each window. If None, this functions calculates the success percent across all trials.
+
+    Returns:
+        float or array (nwindow): success percent = number of successful trials out of all trials attempted.
+    '''
+    segments, _ = preproc.get_trial_segments(events, np.arange(len(events)), start_events, end_events)
+    n_trials = len(segments)
+    success_trials = [np.any(np.isin(success_events, trial)) for trial in segments]
+
+    # If requested, calculate success percent across entire input events
+    if window_size is None:
+        n_success = np.count_nonzero(success_trials)  
+        success_percent = n_success / n_trials
+
+    # Otherwise, compute rolling success percent
+    else:
+        filter_array = np.ones(window_size)
+        success_per_window = signal.convolve(success_trials, filter_array, mode='valid', method='direct')
+        success_percent = success_per_window/window_size
+
+    return success_percent
+
+def calc_success_rate(events, event_times, start_events, end_events, success_events, window_size=None):
+    '''
+    Calculate the number of successful trials per second with a given trial start and end definition.
+
+    Args:
+        events (nevents): events vector, can be codes, event names, anything to match
+        event_times (nevents): time of events in 'events'
+        start_events (int, str, or list, optional): set of start events to match
+        end_events (int, str, or list, optional): set of end events to match
+        success_events (int, str, or list, optional): which events make a trial a successful trial
+        window_size (int, optional): [ntrials] For computing rolling success perecent. How many trials to include in each window. If None, this functions calculates the success percent across all trials.
+
+    Returns:
+        float or array (nwindow): success rate [success/s] = number of successful trials completed per second of time between the start event(s) and end event(s).
+    '''
+    # Get event time information
+    _, times = preproc.get_trial_segments(events, event_times, start_events, end_events)
+    trial_acq_time = times[:,1]-times[:,0]
+    ntrials = times.shape[0]
+    
+    # Get % of successful trials per window 
+    success_perc = calc_success_percent(events, start_events, end_events, success_events, window_size=window_size)
+    
+    # Determine rolling target acquisition time info 
+    if window_size is None:
+        nsuccess = success_perc*ntrials
+        acq_time = np.sum(trial_acq_time)
+
+    else:
+        nsuccess = success_perc*window_size
+        filter_array = np.ones(window_size)
+        acq_time = signal.convolve(trial_acq_time, filter_array, mode='valid', method='direct')
+    
+    success_rate = nsuccess / acq_time
+
+    return success_rate
 
 def compute_path_length_per_trajectory(trajectory):
     '''
@@ -1564,9 +1562,12 @@ def compute_path_length_per_trajectory(trajectory):
     return path_length
 
 
-def time_to_target(event_codes, event_times, target_codes=list(range(81, 89)) , go_cue_code=32 , reward_code=48, only_rewarded_trials=True, per_target_stats=False):
+def time_to_target(event_codes, event_times, target_codes=list(range(81, 89)) , go_cue_code=32 , reward_code=48, per_target_stats=False):
     '''
     This function calculates reach time to target only on rewarded trials given trial aligned event codes and event times See: :func:`aopy.preproc.base.get_trial_segments_and_times` .
+
+    Note:
+        Trials are filtered to only include rewarded trials so that all trials have the same length.
 
     Args:
         event_codes (list) : trial aligned event codes
@@ -1578,14 +1579,13 @@ def time_to_target(event_codes, event_times, target_codes=list(range(81, 89)) , 
         per_target_stats (bool, optional): use if you want to calculate reach time per target
 
     Returns:
-        reach_times (list):
-        reach_times_per_target(list of lists) : optional if per_target_stats == True
+        reach_times (list): time in seconds for each trial between the go cue and the cursor entering peripheral target
+        reach_times_per_target (tuple): optional if per_target_stats == True. Includes:
+            | **reachtime_pertarget (list):** mean reach time per target
+            | **trial_id (list):** target index on each trial
     '''
-    event_times = np.array(event_times)
-    event_codes = np.array(event_codes)
-    if only_rewarded_trials:
-        event_times = np.array([event_times[iTr] for iTr in range(len(event_times)) if reward_code in event_codes[iTr]])
-        event_codes = np.array([event_codes[iTr] for iTr in range(len(event_times)) if reward_code in event_codes[iTr]])
+    event_times = np.array([event_times[iTr] for iTr in range(len(event_times)) if reward_code in event_codes[iTr]])
+    event_codes = np.array([event_codes[iTr] for iTr in range(len(event_times)) if reward_code in event_codes[iTr]])
     leave_center_idx = np.argwhere(event_codes == go_cue_code)[0, 1]
     reach_target_idx = np.argwhere(np.isin(event_codes[0], target_codes))[0][0]
     reachtime = event_times[:, reach_target_idx] - event_times[:, leave_center_idx]
@@ -1603,3 +1603,41 @@ def time_to_target(event_codes, event_times, target_codes=list(range(81, 89)) , 
         return reachtime, (reachtime_pertarget, trial_id)
     else:
         return reachtime
+
+def calc_segment_duration(events, event_times, start_events, end_events, per_target_stats=True, target_codes=list(range(81, 89)), trial_filter=lambda x:x):
+    '''
+    Calculates the duration of a trial segment and optionally report duration per target.
+
+    Args:
+        events (nevents): events vector, can be codes, event names, anything to match
+        event_times (nevents): time of events in 'events'
+        start_events (int, str, or list, optional): set of start events to match
+        end_events (int, str, or list, optional): set of end events to match
+        per_target_stats (bool, optional): whether to return duration on a per-target basis
+        target_codes (list, optional): list of target codes to use for finding targets within trials
+        trial_filter (function, optional): function to apply to each trial's events to determine whether or not to keep it
+
+    Returns:
+        tuple: tuple containing:
+        | **segment_duration (list)**: duration of each segment after filtering
+        | **per_target_stats (tuple)**: optional if per_target_stats == True. Includes:
+            | **per_target_duration (list):** mean segment duration per target
+            | **per_target_idx (list):** target index on each trial
+    '''
+    trial_events, trial_times = preproc.get_trial_segments(events, event_times, start_events, end_events)
+    trial_events, trial_times = zip(*[(e, t) for e, t in zip(trial_events, trial_times) if trial_filter(e)])
+
+    segment_duration = np.array([t[1] - t[0] for t in trial_times])
+
+    if per_target_stats:
+        per_target_duration = []
+        per_target_idx = []
+        target_idx = [np.argwhere(np.isin(te, target_codes))[0][0] for te in trial_events]
+        target_codes = np.array([trial_events[trial_idx][idx] for trial_idx, idx in enumerate(target_idx)])
+
+        for target_idx, iT in enumerate(np.unique(target_codes)):
+            per_target_duration.append(np.mean(segment_duration[target_codes == iT]))
+            per_target_idx.append(target_idx)
+        return segment_duration, (per_target_duration, per_target_idx)
+    else:
+        return segment_duration

--- a/aopy/analysis.py
+++ b/aopy/analysis.py
@@ -1571,7 +1571,7 @@ def time_to_target(event_codes, event_times, per_target_stats=False):
     Args:
         event_codes (list) : event codes
         event_times (list) : event times corresponding to the event codes. These event codes and event times could be the output of preproc.base.get_trial_segments_and_times().
-         get_stats_per_target (bool): optional, use if you want to calculate reach time per target
+        per_target_stats (bool): optional, use if you want to calculate reach time per target
 
     Returns:
         reach_times (list):
@@ -1580,24 +1580,24 @@ def time_to_target(event_codes, event_times, per_target_stats=False):
     CURSOR_ENTER_PERIPHERAL_TARGET = list(range(81, 89))
     CENTER_TARGET_OFF = 32
     REWARD = 48
-    tr_e = np.array([event_codes[iTr] for iTr in range(len(event_times)) if REWARD in event_codes[iTr]])
-    tr_t = np.array([event_times[iTr] for iTr in range(len(event_times)) if REWARD in event_codes[iTr]])
-    leave_center_idx = np.argwhere(tr_e == CENTER_TARGET_OFF)[0, 1]
+    tr_events = np.array([event_codes[iTr] for iTr in range(len(event_times)) if REWARD in event_codes[iTr]])
+    tr_eventtimes = np.array([event_times[iTr] for iTr in range(len(event_times)) if REWARD in event_codes[iTr]])
+    leave_center_idx = np.argwhere(tr_events == CENTER_TARGET_OFF)[0, 1]
 
-    reach_target_idx = np.argwhere(np.isin(tr_e[0], CURSOR_ENTER_PERIPHERAL_TARGET))[0][0]
+    reach_target_idx = np.argwhere(np.isin(tr_events[0], CURSOR_ENTER_PERIPHERAL_TARGET))[0][0]
 
-    rt = tr_t[:, reach_target_idx] - tr_t[:, leave_center_idx]
+    reachtime = tr_eventtimes[:, reach_target_idx] - tr_eventtimes[:, leave_center_idx]
 
     # mean reach time per target
     if per_target_stats:
-        rt_pertarget = []
+        reachtime_pertarget = []
         trial_id = []
-        target_dir = tr_e[:, reach_target_idx]
+        target_dir = tr_events[:, reach_target_idx]
 
         for iT in np.unique(target_dir):
             dir_idx = np.where(target_dir == iT)[0]
-            rt_pertarget.append(rt[dir_idx])
+            reachtime_pertarget.append(reachtime[dir_idx])
             trial_id.append(dir_idx)
-        return rt, (rt_pertarget, trial_id)
+        return reachtime, (reachtime_pertarget, trial_id)
     else:
-        return rt
+        return reachtime

--- a/aopy/analysis.py
+++ b/aopy/analysis.py
@@ -1543,3 +1543,48 @@ def interp_multichannel(x):
     x[nan_idx] = np.interp(idx,xp,fp)
 
     return x
+
+
+'''
+Behavioral metrics 
+'''
+
+def compute_path_length_per_trial(trajectory):
+    '''
+    This function calculates the path length by computing the distance from all points in the trajectory. It returns a single value for path length.
+
+    Args:
+        trajectory (nt x 2): Input trajectory, could be a corsor trajectory or eye trajectory
+
+    Returns:
+        path_length (float): length of the trajectory
+    '''
+    lengths = np.sqrt(np.sum(np.diff(trajectory, axis=0)**2, axis=1)) # compute the distance from all points in trajectory
+    path_length = np.sum(lengths)
+    return path_length
+
+def time_to_target(event_codes, event_times, get_stats_per_target= False):
+    '''
+    This function calculates
+    Args:
+        event_codes (list) :
+        event_times (list):
+        target_direction (list):
+        get_stats_per_target (bool):
+
+    Returns:
+
+    '''
+    CURSOR_ENTER_PERIPHERAL_TARGET = list(range(81, 89))
+    CENTER_TARGET_OFF = 32
+    REWARD = 48
+    tr_e = np.array([event_codes[iTr] for iTr in range(len(event_times)) if REWARD in event_codes[iTr]])
+    tr_t = np.array([event_times[iTr] for iTr in range(len(event_times)) if  REWARD in event_codes[iTr]])
+    leave_center_idx = np.argwhere(tr_e == CENTER_TARGET_OFF)[0]
+    reach_target_idx = np.argwhere(tr_e == CURSOR_ENTER_PERIPHERAL_TARGET)[0]
+    rt = tr_t[:, reach_target_idx] - tr_t[:, leave_center_idx]
+
+    # mean reach time per target
+    target_dir = tr_e[reach_target_idx] - 80
+    for iT in np.unique(target_dir):
+

--- a/aopy/preproc/base.py
+++ b/aopy/preproc/base.py
@@ -414,6 +414,44 @@ def get_trial_segments(events, times, start_events, end_events):
     segment_times = np.array(segment_times)
     return segments, segment_times
 
+def get_trial_segments_and_times(events, times, start_events, end_events):
+    '''
+    This function is similar to get_trial_segments() except it returns the timestamps of all events in event code.
+    Trial align the event codes with corresponding event times.
+
+    Args:
+        events (nt): events vector
+        times (nt): times vector
+        start_events (list): set of start events to match
+        end_events (list): set of end events to match
+
+    Returns:
+        tuple: tuple containing:
+            | **segments (list of list of events):** a segment of each trial
+            | **times (list of list of times):** list of timestamps corresponding to each event in the event code
+
+    '''
+    # Find the indices in events that correspond to start events
+    evt_start_idx = np.where(np.in1d(events, start_events))[0]
+
+    # Extract segments for each start event
+    segments = []
+    segment_times = []
+    for idx_evt in range(len(evt_start_idx)):
+        idx_start = evt_start_idx[idx_evt]
+        idx_end = evt_start_idx[idx_evt] + 1
+
+        # Look forward for a matching end event
+        while idx_end < len(events):
+            if np.in1d(events[idx_end], start_events):
+                break # start event must be followed by end event otherwise not valid
+            if np.in1d(events[idx_end], end_events):
+                segments.append(events[idx_start:idx_end+1])
+                segment_times.append(times[idx_start:idx_end+1])
+                break
+            idx_end += 1
+    return segments, segment_times
+
 def get_data_segments(data, segment_times, samplerate):
     '''
     Gets arbitrary length segments of data from a timeseries

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -676,9 +676,9 @@ class SpectrumTests(unittest.TestCase):
 
 class BehaviorMetricsTests(unittest.TestCase):
 
-    def test_compute_path_length_per_trial(self):
+    def test_compute_path_length_per_trajectory(self):
         pts = [(0,0), (0,1), (3,1), (3,0)]
-        path_length = aopy.analysis.compute_path_length_per_trial(pts)
+        path_length = aopy.analysis.compute_path_length_per_trajectory(pts)
         self.assertEqual(path_length, 5.0)
 
     def test_time_to_target(self):

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -671,8 +671,8 @@ class SpectrumTests(unittest.TestCase):
         f_sg, t_sg, sgram = aopy.analysis.get_sgram_multitaper(
             self.x2, self.fs, self.win_t, self.step_t, self.bw
         )
-        self.assertEqual(sgram.shape[0], self.win_t*self.fs // 2 + 1) # correct freq. bin count
-        self.assertEqual(sgram.shape[-1], self.x2.shape[-1]) # correct channel output count
+        self.assertSequenceEqual(sgram.shape[0], self.win_t*self.fs // 2 + 1) # correct freq. bin count
+        self.assertSequenceEqual(sgram.shape[-1], self.x2.shape[-1]) # correct channel output count
 
 class BehaviorMetricsTests(unittest.TestCase):
 
@@ -693,9 +693,9 @@ class BehaviorMetricsTests(unittest.TestCase):
                  [135.21964, 135.3316, 135.34012, 139.52308, 139.65272],
                  [144.41804, 144.53228, 144.54104, 149.33288, 149.4624 ]]
         rt, rt_pertarget = aopy.analysis.time_to_target(events, times, True)
-        self.assertEqual(rt, [1.30796, 6.79456, 2.403  , 4.18296, 4.79184])
-        self.assertEqual(np.squeeze(rt_pertarget[0]), [1.30796, 4.18296, 2.403  , 4.79184, 6.79456])
-        self.assertEqual(np.squeeze(rt_pertarget[1]), [0, 3, 2, 4, 1])
+        self.assertCountEqual(np.round(rt,2), [1.31, 6.79, 2.4  , 4.18, 4.79])
+        self.assertCountEqual(np.round(np.squeeze(rt_pertarget[0]),2), [1.31, 4.18, 2.4, 4.79, 6.79])
+        self.assertCountEqual(np.squeeze(rt_pertarget[1]), [0, 3, 2, 4, 1])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -695,9 +695,9 @@ class BehaviorMetricsTests(unittest.TestCase):
                  [144., 144., 144., 149., 149.],
                  [154., 154., 154., 160., 160.]]
         rt, rt_pertarget = aopy.analysis.time_to_target(events, times, per_target_stats=True)
-        self.assertCountEqual(rt, [1., 2., 3., 4., 6.]) # difference from go cue to entering peripheral target, skipping unrewarded trial
-        self.assertCountEqual(np.squeeze(rt_pertarget[0]), [[1., 6], 2., 3., 4., 5.,]) # there are two appearances of target 1
-        self.assertCountEqual(np.squeeze(rt_pertarget[1]), [0, 3, 2, 1, 4])
+        np.testing.assert_allclose(rt, [1., 2., 3., 4., 6.]) # difference from go cue to entering peripheral target, skipping unrewarded trial
+        np.testing.assert_allclose(np.squeeze(rt_pertarget[0]), [[1., 6], 2., 3., 4., 5.,]) # there are two appearances of target 1
+        np.testing.assert_allclose(np.squeeze(rt_pertarget[1]), [0, 3, 2, 1, 4])
 
     def test_calc_segment_duration(self):
         events =  [80, 17, 32, 81, 48,
@@ -712,12 +712,15 @@ class BehaviorMetricsTests(unittest.TestCase):
                  135., 135., 135., 139., 139.,
                  144., 144., 144., 149., 149.,
                  154., 154., 154., 160., 160.]
-        rt, rt_pertarget = aopy.analysis.calc_segment_duration(events, times, [32], [48, 128], per_target_stats=True)
-        self.assertCountEqual(rt, [1., 2., 3., 4., 5., 6.]) # difference from go cue to entering peripheral target
-        self.assertCountEqual(np.squeeze(rt_pertarget[1]), [0, 3, 2, 1, 4])
-        rt_pertarget_expected = [[1., 6], [2.], [3.], [4.], [5.],] # there are two appearances of target 1
-        for rt, rt_expected in zip(np.squeeze(rt_pertarget[0]), rt_pertarget_expected):
-            self.assertCountEqual(rt, rt_expected) 
+        rt, target_idx = aopy.analysis.calc_segment_duration(events, times, [32], [48, 128])
+        np.testing.assert_allclose(rt, [1., 2., 3., 4., 5., 6.]) # difference from go cue to entering peripheral target
+        np.testing.assert_allclose(target_idx, [0, 6, 2, 1, 5, 0])
+
+        # With filtering out unsuccessful trials
+        rt, target_idx = aopy.analysis.calc_segment_duration(events, times, [32], [48, 128], trial_filter=lambda x: 48 in x)
+        np.testing.assert_allclose(rt, [1., 2., 3., 4., 6.]) # difference from go cue to entering peripheral target
+        np.testing.assert_allclose(target_idx, [0, 6, 2, 1, 0])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -694,10 +694,10 @@ class BehaviorMetricsTests(unittest.TestCase):
                  [135., 135., 135., 139., 139.],
                  [144., 144., 144., 149., 149.],
                  [154., 154., 154., 160., 160.]]
-        rt, rt_pertarget = aopy.analysis.time_to_target(events, times, per_target_stats=True)
+        rt, target_dir = aopy.analysis.time_to_target(events, times)
         np.testing.assert_allclose(rt, [1., 2., 3., 4., 6.]) # difference from go cue to entering peripheral target, skipping unrewarded trial
-        np.testing.assert_allclose(np.squeeze(rt_pertarget[0]), [[1., 6], 2., 3., 4., 5.,]) # there are two appearances of target 1
-        np.testing.assert_allclose(np.squeeze(rt_pertarget[1]), [0, 3, 2, 1, 4])
+        np.testing.assert_allclose(target_dir, [81, 87, 83, 82, 81]) # there are two appearances of target 1
+
 
     def test_calc_segment_duration(self):
         events =  [80, 17, 32, 81, 48,

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -236,63 +236,6 @@ class CalcTests(unittest.TestCase):
         rms = aopy.analysis.calc_rms(signal, remove_offset=False)
         self.assertAlmostEqual(rms, 1.)
 
-    def test_calc_success_percent(self):
-        # Test integer events
-        events = [0, 2, 4, 6, 0, 2, 3, 6]
-        start_evt = 0
-        end_events = [3, 6]
-        reward_evt = 3
-        success_perc = aopy.analysis.calc_success_percent(events, start_evt, end_events, reward_evt)
-        self.assertEqual(success_perc, 0.5)
-        # Test string events
-        events = [b"TARGET_ON", b"TARGET_OFF", b"TRIAL_END", b"TARGET_ON", b"TARGET_ON", b"TARGET_OFF", b"REWARD"]
-        start_events = [b"TARGET_ON"]
-        end_events = [b"REWARD", b"TRIAL_END"]
-        success_events = [b"REWARD"]
-        success_perc = aopy.analysis.calc_success_percent(events, start_events, end_events, success_events)
-        self.assertEqual(success_perc, 0.5)
-
-        # Test rolling success percent calculation
-        events = [0,2,6, 0,3, 0,2,6, 0,2,6, 0,3, 0,2,6, 0,2,6, 0,3, 0,2,6, 0,2,6, 0,3, 0,2,6]
-        ntrials = 12
-        window_size = 3
-        start_evt = 0
-        end_events = [3, 6]
-        reward_evt = 3
-        expected_success_perc = np.ones(ntrials-window_size+1)*(1/3)
-        success_perc = aopy.analysis.calc_success_percent(events, start_evt, end_events, reward_evt, window_size=window_size)
-        np.testing.assert_allclose(success_perc, expected_success_perc)
-
-    def test_calc_success_rate(self):
-        # Test integer events
-        events = [0, 2, 4, 6, 0, 2, 3, 6]
-        event_times = np.arange(len(events))
-        start_evt = 0
-        end_events = [3, 6]
-        reward_evt = 3
-        success_rate = aopy.analysis.calc_success_rate(events, event_times, start_evt, end_events, reward_evt)
-        self.assertEqual(success_rate, 1/5)
-        # Test string events
-        events = [b"TARGET_ON", b"TARGET_OFF", b"TRIAL_END", b"TARGET_ON", b"TARGET_ON", b"TARGET_OFF", b"REWARD"]
-        start_events = [b"TARGET_ON"]
-        end_events = [b"REWARD", b"TRIAL_END"]
-        success_events = [b"REWARD"]
-        success_rate = aopy.analysis.calc_success_rate(events,event_times, start_events, end_events, success_events)
-        self.assertEqual(success_rate, 1/4)
-
-        # Test rolling success rate calculation
-        events = [0,2,6, 0,3, 0,2,6, 0,2,6, 0,3, 0,2,6, 0,2,6, 0,3, 0,2,6, 0,2,6, 0,3, 0,2,6]
-        event_times = np.arange(len(events))
-        ntrials = 12
-        window_size = 3
-        start_evt = 0
-        end_events = [3, 6]
-        reward_evt = 3
-        expected_success_rate = np.ones(ntrials-window_size+1)*(1/5)
-        success_perc = aopy.analysis.calc_success_rate(events,event_times, start_evt, end_events, reward_evt, window_size=window_size)
-        print(success_perc)
-        np.testing.assert_allclose(success_perc, expected_success_rate)
-
     def test_calc_freq_domain_amplitude(self):
         data = np.sin(np.pi*np.arange(1000)/10) + np.sin(2*np.pi*np.arange(1000)/10)
         samplerate = 1000
@@ -676,6 +619,63 @@ class SpectrumTests(unittest.TestCase):
 
 class BehaviorMetricsTests(unittest.TestCase):
 
+    def test_calc_success_percent(self):
+        # Test integer events
+        events = [0, 2, 4, 6, 0, 2, 3, 6]
+        start_evt = 0
+        end_events = [3, 6]
+        reward_evt = 3
+        success_perc = aopy.analysis.calc_success_percent(events, start_evt, end_events, reward_evt)
+        self.assertEqual(success_perc, 0.5)
+        # Test string events
+        events = [b"TARGET_ON", b"TARGET_OFF", b"TRIAL_END", b"TARGET_ON", b"TARGET_ON", b"TARGET_OFF", b"REWARD"]
+        start_events = [b"TARGET_ON"]
+        end_events = [b"REWARD", b"TRIAL_END"]
+        success_events = [b"REWARD"]
+        success_perc = aopy.analysis.calc_success_percent(events, start_events, end_events, success_events)
+        self.assertEqual(success_perc, 0.5)
+
+        # Test rolling success percent calculation
+        events = [0,2,6, 0,3, 0,2,6, 0,2,6, 0,3, 0,2,6, 0,2,6, 0,3, 0,2,6, 0,2,6, 0,3, 0,2,6]
+        ntrials = 12
+        window_size = 3
+        start_evt = 0
+        end_events = [3, 6]
+        reward_evt = 3
+        expected_success_perc = np.ones(ntrials-window_size+1)*(1/3)
+        success_perc = aopy.analysis.calc_success_percent(events, start_evt, end_events, reward_evt, window_size=window_size)
+        np.testing.assert_allclose(success_perc, expected_success_perc)
+
+    def test_calc_success_rate(self):
+        # Test integer events
+        events = [0, 2, 4, 6, 0, 2, 3, 6]
+        event_times = np.arange(len(events))
+        start_evt = 0
+        end_events = [3, 6]
+        reward_evt = 3
+        success_rate = aopy.analysis.calc_success_rate(events, event_times, start_evt, end_events, reward_evt)
+        self.assertEqual(success_rate, 1/5)
+        # Test string events
+        events = [b"TARGET_ON", b"TARGET_OFF", b"TRIAL_END", b"TARGET_ON", b"TARGET_ON", b"TARGET_OFF", b"REWARD"]
+        start_events = [b"TARGET_ON"]
+        end_events = [b"REWARD", b"TRIAL_END"]
+        success_events = [b"REWARD"]
+        success_rate = aopy.analysis.calc_success_rate(events,event_times, start_events, end_events, success_events)
+        self.assertEqual(success_rate, 1/4)
+
+        # Test rolling success rate calculation
+        events = [0,2,6, 0,3, 0,2,6, 0,2,6, 0,3, 0,2,6, 0,2,6, 0,3, 0,2,6, 0,2,6, 0,3, 0,2,6]
+        event_times = np.arange(len(events))
+        ntrials = 12
+        window_size = 3
+        start_evt = 0
+        end_events = [3, 6]
+        reward_evt = 3
+        expected_success_rate = np.ones(ntrials-window_size+1)*(1/5)
+        success_perc = aopy.analysis.calc_success_rate(events,event_times, start_evt, end_events, reward_evt, window_size=window_size)
+        print(success_perc)
+        np.testing.assert_allclose(success_perc, expected_success_rate)
+
     def test_compute_path_length_per_trajectory(self):
         pts = [(0,0), (0,1), (3,1), (3,0)]
         path_length = aopy.analysis.compute_path_length_per_trajectory(pts)
@@ -686,22 +686,37 @@ class BehaviorMetricsTests(unittest.TestCase):
                    [80, 23, 32, 87, 48] ,
                    [80, 19, 32, 83, 48] ,
                    [80, 18, 32, 82, 48],
-                   [80, 22, 32, 86, 128]]
-        times = [[ 74.24136, 74.34564, 74.35452, 75.66248, 75.79012],
-                 [ 97.60504, 97.71632, 97.7248, 104.51936, 104.64524],
-                 [115.58016, 115.69028, 115.69876, 118.10176, 118.23136],
-                 [135.21964, 135.3316, 135.34012, 139.52308, 139.65272],
-                 [144.41804, 144.53228, 144.54104, 149.33288, 149.4624 ]]
+                   [80, 22, 32, 86, 128], # unrewarded trial should be filtered out
+                   [80, 17, 32, 81, 48],]
+        times = [[ 74., 74., 74., 75., 75.],
+                 [ 97., 97., 97., 99., 99.],
+                 [115., 115., 115., 118., 118.],
+                 [135., 135., 135., 139., 139.],
+                 [144., 144., 144., 149., 149.],
+                 [154., 154., 154., 160., 160.]]
         rt, rt_pertarget = aopy.analysis.time_to_target(events, times, per_target_stats=True)
-        self.assertCountEqual(np.round(rt,2), [1.31, 6.79, 2.4  , 4.18])
-        self.assertCountEqual(np.round(np.squeeze(rt_pertarget[0]),2), [1.31, 4.18, 2.4, 6.79])
+        self.assertCountEqual(rt, [1., 2., 3., 4., 6.]) # difference from go cue to entering peripheral target, skipping unrewarded trial
+        self.assertCountEqual(np.squeeze(rt_pertarget[0]), [3.5, 2., 3., 4.]) # there are two appearances of target 1 => (1. + 6)/2 = 3.5
         self.assertCountEqual(np.squeeze(rt_pertarget[1]), [0, 3, 2, 1])
 
-        # Check without filtering rewarded trials
-        rt, rt_pertarget = aopy.analysis.time_to_target(events, times, only_rewarded_trials=False, per_target_stats=True)
-        self.assertCountEqual(np.round(rt,2), [1.31, 6.79, 2.4  , 4.18, 4.79])
-        self.assertCountEqual(np.round(np.squeeze(rt_pertarget[0]),2), [1.31, 4.18, 2.4, 4.79, 6.79])
-        self.assertCountEqual(np.squeeze(rt_pertarget[1]), [0, 3, 2, 4, 1])
+    def test_calc_segment_duration(self):
+        events =  [80, 17, 32, 81, 48,
+                   80, 23, 32, 87, 48,
+                   80, 19, 32, 83, 48,
+                   80, 18, 32, 82, 48,
+                   80, 22, 32, 86, 128, # unrewarded trial should be filtered out
+                   80, 17, 32, 81, 48]
+        times = [74., 74., 74., 75., 75.,
+                 97., 97., 97., 99., 99.,
+                 115., 115., 115., 118., 118.,
+                 135., 135., 135., 139., 139.,
+                 144., 144., 144., 149., 149.,
+                 154., 154., 154., 160., 160.]
+        rt, rt_pertarget = aopy.analysis.calc_segment_duration(events, times, [32], [48, 128], per_target_stats=True)
+        self.assertCountEqual(rt, [1., 2., 3., 4., 5., 6.]) # difference from go cue to entering peripheral target
+        self.assertCountEqual(np.squeeze(rt_pertarget[0]), [3.5, 2., 3., 4., 5.]) # there are two appearances of target 1 => (1. + 6)/2 = 3.5
+        self.assertCountEqual(np.squeeze(rt_pertarget[1]), [0, 3, 2, 1, 4])
+
 
 
 if __name__ == "__main__":

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -674,6 +674,30 @@ class SpectrumTests(unittest.TestCase):
         self.assertEqual(sgram.shape[0], self.win_t*self.fs // 2 + 1) # correct freq. bin count
         self.assertEqual(sgram.shape[-1], self.x2.shape[-1]) # correct channel output count
 
+class BehaviorMetricsTests(unittest.TestCase):
+
+    def test_compute_path_length_per_trial(self):
+        pts = [(0,0), (0,1), (3,1), (3,0)]
+        path_length = aopy.analysis.compute_path_length_per_trial(pts)
+        self.assertEqual(path_length, 5.0)
+
+    def test_time_to_target(self):
+        events =  [[80, 17, 32, 81, 48],
+                   [80, 23, 32, 87, 48] ,
+                   [80, 19, 32, 83, 48] ,
+                   [80, 18, 32, 82, 48],
+                   [80, 22, 32, 86, 48]]
+        times = [[ 74.24136, 74.34564, 74.35452, 75.66248, 75.79012],
+                 [ 97.60504, 97.71632, 97.7248, 104.51936, 104.64524],
+                 [115.58016, 115.69028, 115.69876, 118.10176, 118.23136],
+                 [135.21964, 135.3316, 135.34012, 139.52308, 139.65272],
+                 [144.41804, 144.53228, 144.54104, 149.33288, 149.4624 ]]
+        rt, rt_pertarget = aopy.analysis.time_to_target(events, times, True)
+        self.assertEqual(rt, [1.30796, 6.79456, 2.403  , 4.18296, 4.79184])
+        self.assertEqual(np.squeeze(rt_pertarget[0]), [1.30796, 4.18296, 2.403  , 4.79184, 6.79456])
+        self.assertEqual(np.squeeze(rt_pertarget[1]), [0, 3, 2, 4, 1])
 
 if __name__ == "__main__":
     unittest.main()
+
+

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -696,8 +696,8 @@ class BehaviorMetricsTests(unittest.TestCase):
                  [154., 154., 154., 160., 160.]]
         rt, rt_pertarget = aopy.analysis.time_to_target(events, times, per_target_stats=True)
         self.assertCountEqual(rt, [1., 2., 3., 4., 6.]) # difference from go cue to entering peripheral target, skipping unrewarded trial
-        self.assertCountEqual(np.squeeze(rt_pertarget[0]), [3.5, 2., 3., 4.]) # there are two appearances of target 1 => (1. + 6)/2 = 3.5
-        self.assertCountEqual(np.squeeze(rt_pertarget[1]), [0, 3, 2, 1])
+        self.assertCountEqual(np.squeeze(rt_pertarget[0]), [[1., 6], 2., 3., 4., 5.,]) # there are two appearances of target 1
+        self.assertCountEqual(np.squeeze(rt_pertarget[1]), [0, 3, 2, 1, 4])
 
     def test_calc_segment_duration(self):
         events =  [80, 17, 32, 81, 48,
@@ -714,10 +714,10 @@ class BehaviorMetricsTests(unittest.TestCase):
                  154., 154., 154., 160., 160.]
         rt, rt_pertarget = aopy.analysis.calc_segment_duration(events, times, [32], [48, 128], per_target_stats=True)
         self.assertCountEqual(rt, [1., 2., 3., 4., 5., 6.]) # difference from go cue to entering peripheral target
-        self.assertCountEqual(np.squeeze(rt_pertarget[0]), [3.5, 2., 3., 4., 5.]) # there are two appearances of target 1 => (1. + 6)/2 = 3.5
         self.assertCountEqual(np.squeeze(rt_pertarget[1]), [0, 3, 2, 1, 4])
-
-
+        rt_pertarget_expected = [[1., 6], [2.], [3.], [4.], [5.],] # there are two appearances of target 1
+        for rt, rt_expected in zip(np.squeeze(rt_pertarget[0]), rt_pertarget_expected):
+            self.assertCountEqual(rt, rt_expected) 
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -671,8 +671,8 @@ class SpectrumTests(unittest.TestCase):
         f_sg, t_sg, sgram = aopy.analysis.get_sgram_multitaper(
             self.x2, self.fs, self.win_t, self.step_t, self.bw
         )
-        self.assertSequenceEqual(sgram.shape[0], self.win_t*self.fs // 2 + 1) # correct freq. bin count
-        self.assertSequenceEqual(sgram.shape[-1], self.x2.shape[-1]) # correct channel output count
+        self.assertEqual(sgram.shape[0], self.win_t*self.fs // 2 + 1) # correct freq. bin count
+        self.assertEqual(sgram.shape[-1], self.x2.shape[-1]) # correct channel output count
 
 class BehaviorMetricsTests(unittest.TestCase):
 
@@ -686,16 +686,23 @@ class BehaviorMetricsTests(unittest.TestCase):
                    [80, 23, 32, 87, 48] ,
                    [80, 19, 32, 83, 48] ,
                    [80, 18, 32, 82, 48],
-                   [80, 22, 32, 86, 48]]
+                   [80, 22, 32, 86, 128]]
         times = [[ 74.24136, 74.34564, 74.35452, 75.66248, 75.79012],
                  [ 97.60504, 97.71632, 97.7248, 104.51936, 104.64524],
                  [115.58016, 115.69028, 115.69876, 118.10176, 118.23136],
                  [135.21964, 135.3316, 135.34012, 139.52308, 139.65272],
                  [144.41804, 144.53228, 144.54104, 149.33288, 149.4624 ]]
-        rt, rt_pertarget = aopy.analysis.time_to_target(events, times, True)
+        rt, rt_pertarget = aopy.analysis.time_to_target(events, times, per_target_stats=True)
+        self.assertCountEqual(np.round(rt,2), [1.31, 6.79, 2.4  , 4.18])
+        self.assertCountEqual(np.round(np.squeeze(rt_pertarget[0]),2), [1.31, 4.18, 2.4, 6.79])
+        self.assertCountEqual(np.squeeze(rt_pertarget[1]), [0, 3, 2, 1])
+
+        # Check without filtering rewarded trials
+        rt, rt_pertarget = aopy.analysis.time_to_target(events, times, only_rewarded_trials=False, per_target_stats=True)
         self.assertCountEqual(np.round(rt,2), [1.31, 6.79, 2.4  , 4.18, 4.79])
         self.assertCountEqual(np.round(np.squeeze(rt_pertarget[0]),2), [1.31, 4.18, 2.4, 4.79, 6.79])
         self.assertCountEqual(np.squeeze(rt_pertarget[1]), [0, 3, 2, 4, 1])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_preproc.py
+++ b/tests/test_preproc.py
@@ -433,6 +433,15 @@ class EventFilterTests(unittest.TestCase):
         self.assertTrue(np.allclose(segments, [[2, 4], [2, 3]]))
         self.assertTrue(np.allclose(times, [[1, 2], [5, 6]]))
 
+    def test_get_trial_segments_and_times(self):
+         events = [0, 2, 4, 6, 0, 2, 3, 6]
+         times = [0, 1, 2, 3, 4, 5, 6, 7]
+         start_evt = 2
+         end_evt = 6
+         segments, times = get_trial_segments_and_times(events, times,  start_evt, end_evt)
+         self.assertTrue(np.allclose(segments, [[2, 4, 6], [2, 3, 6]]))
+         self.assertTrue(np.allclose(times, [[1, 2, 3], [5, 6, 7]]))
+
     def test_locate_trials_with_event(self):
         # Test with ints
         aligned_events = np.array([[2, 7],


### PR DESCRIPTION
I added two functions:  time_to_target() and path_length() in analysis.py 
time_to_target() calculates reach time provided event codes and event times with an option to get per target statistics. Path length calculates the total distance traveled from cursor x and cursor y positions changing across time.  

In the same pull request, also adding another function get_trail_segments_and_times() in preproc.base. This function returns all corresponding event times along with event codes. 

Notes: 
Currently, time_to_target() only estimates reach times on successful targets. In the future, we can make it optional by adding an optional lamba reward filter function in the input. But I will treat this as an enhancement and this pull request need not wait for it. 