### PR TITLE
Leo update get target locations

### DIFF
--- a/aopy/data/bmi3d.py
+++ b/aopy/data/bmi3d.py
@@ -562,11 +562,12 @@ def get_target_locations(preproc_dir, subject, te_id, date, target_indices):
         trials = data['trials']
     except:
         trials = data['bmi3d_trials']
-    locations = []
+    locations = np.nan*np.zeros((len(target_indices), 3))
     for i in range(len(target_indices)):
-        trial_idx = np.where(trials['index'] == target_indices[i])[0][0]
-        locations.append(trials['target'][trial_idx][[0,2,1]])
-    return np.array(locations)
+        trial_idx = np.where(trials['index'] == target_indices[i])[0]
+        if len(trial_idx) > 0:
+            locations[i,:] = trials['target'][trial_idx[0]][[0,2,1]] # use x,y,z format
+    return locations
 
 def get_source_files(preproc_dir, subject, te_id, date):
     '''

--- a/aopy/data/bmi3d.py
+++ b/aopy/data/bmi3d.py
@@ -567,6 +567,8 @@ def get_target_locations(preproc_dir, subject, te_id, date, target_indices):
         trial_idx = np.where(trials['index'] == target_indices[i])[0]
         if len(trial_idx) > 0:
             locations[i,:] = trials['target'][trial_idx[0]][[0,2,1]] # use x,y,z format
+        else:
+            raise ValueError(f"Target index {target_indices[i]} not found")
     return locations
 
 def get_source_files(preproc_dir, subject, te_id, date):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -397,6 +397,10 @@ class TestGetPreprocDataFuncs(unittest.TestCase):
         locs = get_target_locations(write_dir, self.subject, self.te_id, self.date, target_indices)
         self.assertEqual(locs.shape, (9, 3))
 
+        # If you supply an invalid target index it should raise an error
+        target_indices = np.array([10])
+        self.assertRaises(ValueError, lambda: get_target_locations(write_dir, self.subject, self.te_id, self.date, target_indices))
+
     def test_get_source_files(self):
         subject = 'beignet'
         te_id = 5974


### PR DESCRIPTION
using `get_target_locations()` is tricky because if you try to get target 10 and there are only 9 targets, it gives you a cryptic error about index 0 being out of bounds. I added a more descriptive error message to help with debugging. 