### PR TITLE
Fix no event bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # analyze
 For installing and using the code, see the documentation [on readthedocs](https://analyze.readthedocs.io/en/latest/)
 
-For contributing, see the [wiki](https://github.com/aolabNeuro/analyze/wiki)
+For contributing, see the [github](https://github.com/aolabNeuro/analyze/)

--- a/aopy/preproc/bmi3d.py
+++ b/aopy/preproc/bmi3d.py
@@ -220,7 +220,7 @@ def _parse_bmi3d_v1(data_dir, files):
         ecube_sync_data = utils.mask_and_shift(digital_data, event_bit_mask)
         ecube_sync_timestamps, ecube_sync_events = utils.detect_edges(ecube_sync_data, digital_samplerate, 
             rising=True, falling=False)
-        if np.min(np.diff(ecube_sync_timestamps)) < metadata_dict['sync_pulse_width']:
+        if len(ecube_sync_timestamps) > 2 and np.min(np.diff(ecube_sync_timestamps)) < metadata_dict['sync_pulse_width']:
             print(f"Correcting sync pulse width in {ecube_filename}")
             # There can occasionally be a compression of the pause event that smears it across multiple 
             # digital lines _-‾ and it shows up as multiple events very close together.

--- a/docs/source/test-guidelines.rst
+++ b/docs/source/test-guidelines.rst
@@ -267,6 +267,10 @@ datasets here as they become available.
      - BMI3D data - a laser only experiment which does not contain any task data
    * - `2022-10-02_BMI3D_te6890`
      - eCube data - sync version 12 - including some real headstage ECoG data, although it is truncated in length
+   * - `beig20230109_15_te7977.hdf`
+     - BMI3D data - tracking task experiment
+   * - `2023-01-09_BMI3D_te7977`
+     - eCube data - sync version 13 - from the above tracking task experiment, including an instance of the "pause bug"
    * - `test20210330_12_te1254.hdf`
      - BMI3D data - sync version 2
    * - `fake ecube data`

--- a/docs/source/test-guidelines.rst
+++ b/docs/source/test-guidelines.rst
@@ -258,9 +258,9 @@ datasets here as they become available.
    * - `beig20210929_02_te2949.hdf`
      - BMI3D data - eyetracking test
    * - `2021-09-30_BMI3D_te2952`
-     - eCube data - another eyetracking test
+     - eCube data - another eyetracking test with 0 trials
    * - `beig20210930_02_te2952.hdf`
-     - BMI3D data - another eyetracking test
+     - BMI3D data - another eyetracking test with 0 trials
    * - `2021-12-13_BMI3D_te3498`
      - eCube data - sync version 7
    * - `beig20221002_09_te6890.hdf`

--- a/tests/test_preproc.py
+++ b/tests/test_preproc.py
@@ -818,6 +818,12 @@ class TestPrepareExperiment(unittest.TestCase):
         data, metadata = parse_bmi3d(data_dir, files) # with ecube data
         self.assertEqual(len(data['sync_events']), len(data['bmi3d_events']))
 
+        # Test a file with no sync events to make sure we're not breaking things
+        files['hdf'] = 'beig20221002_09_te6890.hdf'
+        files['ecube'] = '2022-10-02_BMI3D_te6890'
+        data, metadata = parse_bmi3d(data_dir, files) # with ecube data
+        self.assertEqual(len(data['sync_events']), len(data['bmi3d_events']))
+
     def test_parse_oculomatic(self):
         files = {}
         files['ecube'] = '2021-09-30_BMI3D_te2952'

--- a/tests/test_preproc.py
+++ b/tests/test_preproc.py
@@ -666,7 +666,13 @@ class TestPrepareExperiment(unittest.TestCase):
         end_states = [239] 
         trial_states, trial_idx = get_trial_segments(events['code'], events['timestamp'], start_states, end_states)
         self.assertEqual(len(trial_states), 10)
-    
+
+        # Test a file with no sync events to make sure we're not breaking things
+        files['hdf'] = 'beig20210930_02_te2952.hdf'
+        files['ecube'] = '2021-09-30_BMI3D_te2952'
+        data, metadata = parse_bmi3d(data_dir, files) # with ecube data
+        self.assertEqual(len(data['sync_events']), 3)
+
     def test_parse_bmi3d_v8(self):
         pass
 
@@ -815,12 +821,6 @@ class TestPrepareExperiment(unittest.TestCase):
         # filename = utils.save_test_signal_ecube(analog_data, data_dir, 1, datasource='AnalogPanel')
 
         # There is a pause bug that should be corrected
-        data, metadata = parse_bmi3d(data_dir, files) # with ecube data
-        self.assertEqual(len(data['sync_events']), len(data['bmi3d_events']))
-
-        # Test a file with no sync events to make sure we're not breaking things
-        files['hdf'] = 'beig20221002_09_te6890.hdf'
-        files['ecube'] = '2022-10-02_BMI3D_te6890'
         data, metadata = parse_bmi3d(data_dir, files) # with ecube data
         self.assertEqual(len(data['sync_events']), len(data['bmi3d_events']))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -103,15 +103,10 @@ class TestDigitalCalc(unittest.TestCase):
 
         # check data values instead of a single bit
         test_02 = [0b11, 0, 0, 0, 0, 0, 0, 0b01, 0b10, 0b01, 0b11, 0b01, 0b00, 0b10, 0b00, 0b01, 0, 0b01, 0, 0b01, 0, 0b01, 0]
-        ts, values = detect_edges(test_02, 1, falling=False, check_alternating=False) # when would you ever not check_alternating?
+        ts, values = detect_edges(test_02, 1, falling=False, check_alternating=False)
         self.assertEqual(len(ts), 9)
         np.testing.assert_allclose(ts, [7, 8, 9, 10, 13, 15, 17, 19, 21])
         np.testing.assert_allclose(values, [1, 2, 1, 3, 2, 1, 1, 1, 1])
-
-        ts, values = detect_edges(test_02, 1, falling=False)
-        self.assertEqual(len(ts), 8)
-        np.testing.assert_allclose(ts, [7, 8, 10, 13, 15, 17, 19, 21])
-        np.testing.assert_allclose(values, [1, 2, 3, 2, 1, 1, 1, 1])
 
         # test that if there are multiple of the same edge only the last one counts
         test_valid = [0, 0, 3, 0, 3, 2, 2, 0, 1, 7, 3, 2, 2, 0]
@@ -121,25 +116,14 @@ class TestDigitalCalc(unittest.TestCase):
 
         # Test using min_pulse_width
         test_bool = [1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0]
-        test_01 = [0, 0, 4, 0, 3, 2, 0, 0, 0, 0, 0]
+        test_int = [0, 0, 4, 0, 3, 2, 0, 0, 0, 0, 0]
         ts, values = detect_edges(test_bool, 1, min_pulse_width=4)
         np.testing.assert_allclose(ts,  [2, 8])  # Can't get falling edge without rising edge in this case
         np.testing.assert_allclose(values, [1, 0])
         
-        ts, values = detect_edges(test_01, 1, min_pulse_width=4)
+        ts, values = detect_edges(test_int, 1, min_pulse_width=4)
         np.testing.assert_allclose(ts, [4, 8]) # the rising edge isn't finished until index 4 now
         np.testing.assert_allclose(values, [7, 0])
-
-        test_02 = [0, 0, 4, 0, 3, 2, 0, 2, 0, 0, 0]
-        test_03 = [0, 0, 4, 0, 3, 2, 0, 0, 2, 0, 0]
-        ts, values = detect_edges(test_02, 1, min_pulse_width=4)
-        # np.testing.assert_allclose(ts, [4, 8])
-        # np.testing.assert_allclose(values, [7, 0]) # returns [7,2] because 2 is extended to the final idx
-
-        ts, values = detect_edges(test_03, 1, min_pulse_width=4)
-        np.testing.assert_allclose(ts, [4, 9]) # returns [4,8] because 2 is extended to the final idx
-        np.testing.assert_allclose(values, [7, 0])     
-        
 
 
     def test_get_pulse_edge_times(self):


### PR DESCRIPTION
There was a bug for experiments that don't have sync events that prevented preprocessing. I added a check of the length of sync events to avoid this problem.