### PR TITLE
Trial_align_times

### DIFF
--- a/tests/test_preproc.py
+++ b/tests/test_preproc.py
@@ -434,7 +434,16 @@ class EventFilterTests(unittest.TestCase):
         trial_aligned, trial_indices = trial_align_times(timestamps, trigger_times, time_before, time_after, subtract=True)
         self.assertTrue(np.allclose(trial_aligned[0], np.array([6, 7, 10])-5))
 
-
+    def test_trial_align_timestamps(self):
+        timestamps = np.arange(10,40)
+        trigger_times = np.array([12, 16, 21, 29, 35])
+        time_before = 3
+        time_after = 3
+        trial_aligned, trial_indices = trial_align_timestamps(timestamps, trigger_times, time_before, time_after, subtract=False)
+        self.assertEqual(trial_aligned.shape[0], 4)
+        self.assertEqual(trial_aligned[1,1], 19)
+        self.assertTrue(np.all(trial_aligned == timestamps[trial_indices]))
+        
     def test_get_trial_segments(self):
         events = [0, 2, 4, 6, 0, 2, 3, 6]
         times = np.arange(len(events))


### PR DESCRIPTION
#379 Added trial_aling_timestamps function. which aligns timestamps on triggered times and also returns indices to align other data. This function assumes timestamps whose intervals are equal (ex. [1,2,3,4,5,6,7,8]). 

There is a similar function (trial_align_times) in aopy. However, each trial split by this function often has different number of data points. But this function can deal with timestamps which is not equally spaced (ex. [1,5,8,9,15]). So I thought I should make trial_align_timestamps without deleting trial_align_times.