### PR TITLE
remove str() from db.list_entry_details

### DIFF
--- a/aopy/data/db.py
+++ b/aopy/data/db.py
@@ -430,7 +430,7 @@ def list_entry_details(sessions):
             | **te_id (list):** list of task entry ids
             | **date (list):** list of dates
     '''
-    return zip(*[(te.subject, str(te.id), str(te.date)) for te in sessions])
+    return zip(*[(te.subject, te.id, te.date) for te in sessions])
 
 def group_entries(sessions, grouping_fn=lambda te: te.date):
     '''

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1004,8 +1004,8 @@ class DatabaseTests(unittest.TestCase):
         sessions = db.lookup_sessions(task_desc='task_desc')
         subject, te_id, date = db.list_entry_details(sessions)
         self.assertCountEqual(subject, ['test_subject'])
-        self.assertCountEqual(te_id, ['2'])
-        self.assertCountEqual(date, ['2023-06-26'])
+        self.assertCountEqual(te_id, [2])
+        self.assertCountEqual([str(d) for d in date], ['2023-06-26'])
         
     def test_group_entries(self):
 


### PR DESCRIPTION
keeping date as a datetime object makes comparisons easier later