### PR TITLE
always include eye closed mask

### DIFF
--- a/aopy/preproc/wrappers.py
+++ b/aopy/preproc/wrappers.py
@@ -181,6 +181,7 @@ def proc_eyetracking(data_dir, files, result_dir, exp_filename, result_filename,
     The data is prepared into HDF datasets:
     
     eye_data:
+        eye_closed_mask (nt, nch): boolean mask of when the eyes are closed
         raw_data (nt, nch): raw eye data
         calibrated_data (nt, nch): calibrated eye data
         coefficients (nch, 2): linear regression coefficients

--- a/aopy/preproc/wrappers.py
+++ b/aopy/preproc/wrappers.py
@@ -262,7 +262,10 @@ def proc_eyetracking(data_dir, files, result_dir, exp_filename, result_filename,
     except (KeyError, ValueError):
         # If there is no cursor data or there aren't enough trials, this will fail. 
         # We should still save the eye data, just don't include the calibrated data
-        eye_dict = {'raw_data': eye_data}
+        eye_dict = {
+            'eye_closed_mask': eye_mask,
+            'raw_data': eye_data
+        }
 
     # Save everything into the HDF file
     if save_res:

--- a/tests/test_preproc.py
+++ b/tests/test_preproc.py
@@ -937,6 +937,7 @@ class TestPrepareExperiment(unittest.TestCase):
         self.assertIsNotNone(eye)
         self.assertIsNotNone(meta)
         self.assertIn('raw_data', eye)
+        self.assertIn('eye_closed_mask', eye)
         self.assertIn('samplerate', meta)
 
         # This dataset has more trials


### PR DESCRIPTION
minor fix to always save the eye closed mask. it was getting thrown away for data without calibration