### PR TITLE
maybe load corrupted files

### DIFF
--- a/aopy/data/bmi3d.py
+++ b/aopy/data/bmi3d.py
@@ -121,8 +121,8 @@ def load_ecube_data(data_dir, data_source, channels=None):
     timeseries_data = np.zeros((n_samples, len(channels)), dtype=dtype)
     n_read = 0
     for chunk in _process_channels(data_dir, data_source, channels, metadata['n_samples'], dtype=dtype):
-        chunk_len = chunk.shape[0]
-        timeseries_data[n_read:n_read+chunk_len,:] = chunk
+        chunk_len = min(chunk.shape[0], n_samples-n_read)
+        timeseries_data[n_read:n_read+chunk_len,:] = chunk[:chunk_len,:] # Deal with potentially corrupted data
         n_read += chunk_len
     return timeseries_data
 

--- a/aopy/whitematter/dataset.py
+++ b/aopy/whitematter/dataset.py
@@ -311,6 +311,10 @@ class Dataset:
                 chancount = fileattr[1]
                 dattype = fileattr[6]
 
+                if chunksize % chancount != 0:
+                    chunksize -= chunksize % chancount
+                    print("Warning: incomplete binary file samples dropped in {}.".format(filename))
+
                 if debug is True:
                     print("    {} [{}:{}]: {}ch x {}".format(\
                     os.path.basename(filename), \


### PR DESCRIPTION
don't know if it works, but might be able to load corrupted ecube files by truncating the end where the corruption happened