### PR TITLE
remove default filtering in get_interp_kinematics

### DIFF
--- a/aopy/data/bmi3d.py
+++ b/aopy/data/bmi3d.py
@@ -255,7 +255,7 @@ def filter_lfp_from_broadband(broadband_filepath, result_filepath, mean_subtract
         n_ch = 0
         while n_ch < n_channels:
             broadband_chunk = bb_data[n_bb_samples:n_bb_samples+time_chunksize, n_ch:n_ch+channel_chunksize]
-            lfp_chunk = precondition.filter_lfp(broadband_chunk, samplerate, **filter_kwargs)
+            lfp_chunk, _ = precondition.filter_lfp(broadband_chunk, samplerate, **filter_kwargs)
             chunk_len = lfp_chunk.shape[0]
             dset[n_lfp_samples:n_lfp_samples+chunk_len,n_ch:n_ch+channel_chunksize] = lfp_chunk
             n_ch += channel_chunksize
@@ -326,7 +326,7 @@ def filter_lfp_from_ecube(ecube_filepath, result_filepath, mean_subtract=True, d
     # Filter broadband data into LFP directly into the hdf file
     n_lfp_samples = 0
     for broadband_chunk in load_ecube_data_chunked(ecube_filepath, 'Headstages', chunksize=chunksize):
-        lfp_chunk = precondition.filter_lfp(broadband_chunk, samplerate, **filter_kwargs)
+        lfp_chunk, _ = precondition.filter_lfp(broadband_chunk, samplerate, **filter_kwargs)
         chunk_len = lfp_chunk.shape[0]
         dset[n_lfp_samples:n_lfp_samples+chunk_len,:] = lfp_chunk
         n_lfp_samples += chunk_len
@@ -538,10 +538,24 @@ def get_ecube_digital_input_times(path, data_dir, ch):
 #####################
 def get_interp_kinematics(exp_data, exp_metadata, datatype='cursor', samplerate=1000):
     '''
-    Gets interpolated and filtered kinematic data from preprocessed experiment 
-    data to the desired sampling rate. Cursor kinematics are returned in 
-    screen coordinates, while other kinematics are returned in their original
-    coordinate system (e.g. hand kinematics in optitrack coordinates).
+    Gets interpolated kinematic data from preprocessed experiment data to the desired 
+    sampling rate. Cursor kinematics are returned in screen coordinates, while other 
+    kinematics are returned in their original coordinate system (e.g. hand kinematics 
+    in optitrack coordinates).
+
+    Args:
+        exp_data (dict): A dictionary containing the experiment data.
+        exp_metadata (dict): A dictionary containing the experiment metadata.
+        datatype (str, optional): The type of kinematic data to interpolate. 
+            For 'hand' kinematics, interp the 'clean_hand_position' experiment data
+            For 'cursor' kinematics, interp the x and z position of the 'cursor' task data
+            For other kinematics, try to interp exp_data['task'][datatype]
+        samplerate (float, optional): The desired output sampling rate in Hz. 
+            Defaults to 1000.
+
+    Returns:
+        data_time (ns, ...): Kinematic data interpolated and filtered 
+            to the desired sampling rate.
 
     Examples:
         
@@ -613,19 +627,9 @@ def get_interp_kinematics(exp_data, exp_metadata, datatype='cursor', samplerate=
 
         .. image:: _images/get_interp_user_tracking.png
 
-    Args:
-        exp_data (dict): A dictionary containing the experiment data.
-        exp_metadata (dict): A dictionary containing the experiment metadata.
-        datatype (str, optional): The type of kinematic data to interpolate. 
-            For 'hand' kinematics, interp the 'clean_hand_position' experiment data
-            For 'cursor' kinematics, interp the x and z position of the 'cursor' task data
-            For other kinematics, try to interp exp_data['task'][datatype]
-        samplerate (float, optional): The desired output sampling rate in Hz. 
-            Defaults to 1000.
-
-    Returns:
-        data_time (ns, ...): Kinematic data interpolated and filtered 
-            to the desired sampling rate.
+    Changes:
+        2023-10-20: Added support for 'targets' datatype
+        2024-01-29: Removed kinematic filtering below 15 Hz. See :func:`~aopy.precondition.filter_kinematics`.
     '''
     kwargs = {}
 
@@ -651,7 +655,6 @@ def get_interp_kinematics(exp_data, exp_metadata, datatype='cursor', samplerate=
     elif datatype == 'targets':
         data_cycles = get_target_events(exp_data, exp_metadata)
         clock = exp_data['events']['timestamp']
-        kwargs['remove_nan'] = False # In this case we need to keep NaN values.
     elif datatype in exp_data['task'].dtype.names:
         data_cycles = exp_data['task'][datatype]
     else:
@@ -660,8 +663,7 @@ def get_interp_kinematics(exp_data, exp_metadata, datatype='cursor', samplerate=
     # Interpolate
     data_time = sample_timestamped_data(data_cycles, clock, samplerate, 
                                         upsamplerate=10000, append_time=10, **kwargs)
-    if 'remove_nan' not in kwargs:
-        data_time = precondition.filter_kinematics(data_time, samplerate)
+
     return data_time
 
 def get_velocity_segments(*args, norm=True, **kwargs):

--- a/aopy/data/bmi3d.py
+++ b/aopy/data/bmi3d.py
@@ -655,6 +655,7 @@ def get_interp_kinematics(exp_data, exp_metadata, datatype='cursor', samplerate=
     elif datatype == 'targets':
         data_cycles = get_target_events(exp_data, exp_metadata)
         clock = exp_data['events']['timestamp']
+        kwargs['remove_nan'] = False # In this case we need to keep NaN values.
     elif datatype in exp_data['task'].dtype.names:
         data_cycles = exp_data['task'][datatype]
     else:

--- a/aopy/precondition/base.py
+++ b/aopy/precondition/base.py
@@ -758,11 +758,13 @@ def filter_lfp(broadband_data, broadband_samplerate, lfp_samplerate=1000., low_c
         buttord (int, optional): order for butterworth low-pass filter. Defaults to 4.
 
     Returns:
-        (nt', ...): lfp data
+        tuple: tuple containing:
+        | lfp_data **(nt', ...):** downsampled filtered lfp data
+        | **samplerate (float):** sampling rate of the lfp data
     '''
     b, a = butter(buttord, low_cut, btype='lowpass', fs=broadband_samplerate)
     filtered_data = filtfilt(b, a, broadband_data, axis=0)
-    return downsample(filtered_data, broadband_samplerate, lfp_samplerate)
+    return downsample(filtered_data, broadband_samplerate, lfp_samplerate), lfp_samplerate
 
 def filter_spikes(broadband_data, samplerate, low_pass=500, high_pass=7500, buttord=3):
     '''
@@ -796,7 +798,9 @@ def filter_kinematics(kinematic_data, samplerate, low_cut=15, buttord=4):
         buttord (int, optional): order for butterworth low-pass filter. Defaults to 4.
 
     Returns:
-        (nt, ...): filtered kinematics data
+        tuple: tuple containing:
+        | **filtere_data (nt, ...):** filtered kinematics data
+        | **samplerate (float):** sampling rate of the kinematics data
 
     Examples:
 
@@ -805,7 +809,7 @@ def filter_kinematics(kinematic_data, samplerate, low_cut=15, buttord=4):
             fs = 100
             x_single, t = utils.generate_test_signal(T=5, fs, 1, 5)
             x_noise, t = utils.generate_test_signal(T=5, fs=fs, freq=[1,3,30], a=[5, 2, 0.5], noise=0.2)
-            x_filt = precondition.filter_kinematics(x, fs, low_cut=15, buttord=4)
+            x_filt, _ = precondition.filter_kinematics(x, fs, low_cut=15, buttord=4)
             fig, ax = plt.subplot_mosaic([['A', 'B'],['C', 'C']])
         
             ax['A'].plot(t, x_noise, label='Noisy signal')
@@ -828,4 +832,4 @@ def filter_kinematics(kinematic_data, samplerate, low_cut=15, buttord=4):
     '''
     b, a = butter(buttord, low_cut, btype='lowpass', fs=samplerate)
     filtered_data = filtfilt(b, a, kinematic_data, axis=0)
-    return filtered_data
+    return filtered_data, samplerate

--- a/aopy/precondition/base.py
+++ b/aopy/precondition/base.py
@@ -759,7 +759,7 @@ def filter_lfp(broadband_data, broadband_samplerate, lfp_samplerate=1000., low_c
 
     Returns:
         tuple: tuple containing:
-        | lfp_data **(nt', ...):** downsampled filtered lfp data
+        | **lfp_data (nt', ...):** downsampled filtered lfp data
         | **samplerate (float):** sampling rate of the lfp data
     '''
     b, a = butter(buttord, low_cut, btype='lowpass', fs=broadband_samplerate)

--- a/aopy/precondition/eye.py
+++ b/aopy/precondition/eye.py
@@ -19,7 +19,9 @@ def filter_eye(eye_pos, samplerate, downsamplerate=1000, low_cut=200, buttord=4)
         taper_len (float, optional): length of tapers to use in multitaper lowpass filter
 
     Returns:
-        (nt, nch) eye pos: eye position after filtering and downsampling
+        tuple: tuple containing:
+        | **eye_pos (nt, nch):** eye position after filtering and downsampling
+        | **samplerate (float):** sampling rate of the returned eye data
     '''
     # Lowpass filter
     b, a = butter(buttord, low_cut, btype='lowpass', fs=samplerate)
@@ -28,8 +30,10 @@ def filter_eye(eye_pos, samplerate, downsamplerate=1000, low_cut=200, buttord=4)
     # Downsample
     if samplerate > downsamplerate:
         eye_pos = downsample(eye_pos, samplerate, downsamplerate)
+    else:
+        downsamplerate = samplerate
 
-    return eye_pos
+    return eye_pos, downsamplerate
 
 def convert_pos_to_speed(eye_pos, samplerate):
     '''
@@ -122,7 +126,7 @@ def detect_saccades(eye_pos, samplerate, thr=None, num_sd=1.5, intersaccade_min=
         " duration must be longer than the minimum intersaccade interval")
     
     if lowpass_filter_freq is not None:
-        eye_pos = filter_eye(eye_pos, samplerate, samplerate, low_cut=lowpass_filter_freq)    
+        eye_pos, _ = filter_eye(eye_pos, samplerate, samplerate, low_cut=lowpass_filter_freq)    
     eye_accel = convert_pos_to_accel(eye_pos, samplerate)
 
     # Set an appropritate threshold to detect saccades

--- a/aopy/preproc/bmi3d.py
+++ b/aopy/preproc/bmi3d.py
@@ -279,7 +279,7 @@ def _parse_bmi3d_v1(data_dir, files):
         # Analog cursor out (A3, A4) since version 11
         if 'cursor_x_ach' in metadata_dict and 'cursor_z_ach' in metadata_dict:
             cursor_analog = ecube_analog[:, [metadata_dict['cursor_x_ach'], metadata_dict['cursor_z_ach']]]
-            cursor_analog = precondition.filter_kinematics(cursor_analog, samplerate=analog_samplerate)
+            cursor_analog, _ = precondition.filter_kinematics(cursor_analog, samplerate=analog_samplerate)
             cursor_analog_samplerate = 1000
             cursor_analog = precondition.downsample(cursor_analog, analog_samplerate, cursor_analog_samplerate)
             max_voltage = 3.34 # using teensy 3.6

--- a/aopy/preproc/oculomatic.py
+++ b/aopy/preproc/oculomatic.py
@@ -76,7 +76,7 @@ def parse_oculomatic(data_dir, files, samplerate=1000, max_memory_gb=1.0, debug=
         # mask_chunk = precondition.downsample(mask_chunk, analog_metadata['samplerate'], samplerate)
         # mask_chunk = mask_chunk > 0.5 # downsample takes a mean over boolean, this makes it back into a boolean
         mask_chunk = mask_chunk[::downsample_factor,:]
-        analog_chunk = filter_eye(analog_chunk, analog_metadata['samplerate'], downsamplerate=samplerate, **filter_kwargs)
+        analog_chunk, _ = filter_eye(analog_chunk, analog_metadata['samplerate'], downsamplerate=samplerate, **filter_kwargs)
         chunk_len = analog_chunk.shape[0]
         downsample_data[n_samples:n_samples+chunk_len,:] = analog_chunk
         downsample_mask[n_samples:n_samples+chunk_len,:] = mask_chunk

--- a/tests/test_precondition.py
+++ b/tests/test_precondition.py
@@ -298,7 +298,8 @@ class FilterTests(unittest.TestCase):
     def test_filter_lfp(self):
         
         test_data = np.random.uniform(size=(100000,2))
-        filt = precondition.filter_lfp(test_data, 25000)
+        filt, fs = precondition.filter_lfp(test_data, 25000)
+        self.assertEqual(fs, 1000)
         self.assertEqual(filt.shape, (100000/25, 2))
         self.assertAlmostEqual(np.mean(test_data), np.mean(filt), places=3)
 
@@ -311,7 +312,7 @@ class FilterTests(unittest.TestCase):
 
     def test_filter_kinematics(self):
         fs = 100
-        fn = lambda x: precondition.filter_kinematics(x, fs, low_cut=15, buttord=4)
+        fn = lambda x: precondition.filter_kinematics(x, fs, low_cut=15, buttord=4)[0]
         HelperFunctions.test_filter(fn, fs=fs, T=5, freq=[1,3,30], a=[5, 2, 0.5], noise=0.2)
         fname = 'filter_kinematics.png'
         savefig(docs_dir, fname)
@@ -504,7 +505,8 @@ class EyeTests(unittest.TestCase):
         orig = self.calibrated_eye_data[:int(self.samplerate*length)]
         t_orig = np.arange(len(orig))/self.samplerate
         samplerate = 1000
-        data_filt = filter_eye(orig, self.samplerate, downsamplerate=samplerate)
+        data_filt, new_samplerate = filter_eye(orig, self.samplerate, downsamplerate=samplerate)
+        self.assertEqual(new_samplerate, samplerate)
 
         le_orig = orig[:,:2]
         le_filt = data_filt[:,:2]
@@ -544,7 +546,7 @@ class EyeTests(unittest.TestCase):
 
         # Important to low-pass filter before computing acceleration
         samplerate = 1000
-        pos_filt = filter_eye(pos, self.samplerate, downsamplerate=samplerate)
+        pos_filt, _ = filter_eye(pos, self.samplerate, downsamplerate=samplerate)
         accel = convert_pos_to_accel(pos_filt, samplerate)
         fig, ax = plt.subplots(4,1)
         plot_timeseries(pos, self.samplerate, ax=ax[0])        
@@ -564,7 +566,7 @@ class EyeTests(unittest.TestCase):
 
     def test_detect_saccades(self):
         samplerate = 1000
-        le_data_filt = filter_eye(self.calibrated_eye_data[:,:2], self.samplerate, downsamplerate=samplerate)
+        le_data_filt, _ = filter_eye(self.calibrated_eye_data[:,:2], self.samplerate, downsamplerate=samplerate)
 
         onset, duration, distance = detect_saccades(le_data_filt, samplerate, debug=True, debug_window=(0, 5))
         savefig(docs_dir, 'detect_saccades.png')


### PR DESCRIPTION
we can use preproc=aopy.precondition.filter_kinematics() instead if needed