### PR TITLE
Get a confidence interval and compute overlap ratio between 2 confidence intervals

### DIFF
--- a/aopy/analysis/base.py
+++ b/aopy/analysis/base.py
@@ -1706,3 +1706,32 @@ def get_confidence_interval(sample, hist_bins, alpha=0.025, ax=None, **kwarg):
         ax2.set(ylabel='cdf')
         
     return [lower_bound, upper_bound]
+
+def calc_confidence_interval_overlap(CI1, CI2):
+    '''
+    Calculate the overlap between two confidence intervals.
+
+    Parameters:
+        CI1 (tuple or list): Tuple containing the lower and upper bounds of the first confidence interval.
+        CI2 (tuple or list): Tuple containing the lower and upper bounds of the second confidence interval.
+
+    Returns:
+        (float): Overlap ratio (0 to 1) between the two confidence intervals.
+    '''
+    
+    lower1, upper1 = CI1
+    lower2, upper2 = CI2
+    
+    # Calculate overlap
+    overlap_lower = max(lower1, lower2)
+    overlap_upper = min(upper1, upper2)
+    overlap_width = max(0, overlap_upper - overlap_lower)
+
+    # Calculate widths of the intervals
+    width1 = upper1 - lower1
+    width2 = upper2 - lower2
+    
+    # Calculate overlap ratio
+    overlap = (overlap_width / min(width1, width2))
+    
+    return overlap

--- a/aopy/analysis/base.py
+++ b/aopy/analysis/base.py
@@ -1667,3 +1667,42 @@ def calc_corr2_map(data1, data2, knlsz=15, align_maps=False):
     NCC[nan_idx1] = np.nan
     
     return NCC, shifts
+
+def get_confidence_interval(sample, hist_bins, alpha=0.025, ax=None, **kwarg):
+    '''
+    Compute a confidence interval from samples, not the mean of samples
+    If you want to compute it for the mean of samples, use scipy.stats.t.interval.
+    
+    Args:
+        sample (nsamples): data samples
+        hist_bins (int or sequence of scalars): the number of bins or array of bin edges
+        alpha (float): significance level to define a confidece interval. Defaults to 0.025
+        ax (pyplot.Axes, optional): axis on which to plot data histogram and confidence interval. Defaults to None.
+        kwargs (dict): additional keyword arguments to pass to ax.hist()
+        
+    Returns:
+        (list): lower and upper bounds in the confidence interval
+    '''
+    
+    # Compute cdf from histogram in samples
+    count, bin_edges = np.histogram(sample, bins=hist_bins)
+    bin_edges = bin_edges[1:] - (bin_edges[1] - bin_edges[0])/2 # Use center of bins
+    pdf = count / sum(count)
+    cdf = np.cumsum(pdf)
+    
+    # Compute lower and upper bound
+    lower_bound = bin_edges[np.where(cdf>alpha)[0][0]]
+    upper_bound = bin_edges[np.where(cdf<1-alpha)[0][-1]]
+    
+    # Plot histogram and confidence interval
+    if ax is not None:
+        ax.hist(sample,**kwarg)
+        ax.axvline(lower_bound, color='r', linestyle='--')
+        ax.axvline(upper_bound, color='r', linestyle='--')
+        ax.set(ylabel='# count')
+        
+        ax2 = ax.twinx()
+        ax2.plot(bin_edges, cdf, 'k')
+        ax2.set(ylabel='cdf')
+        
+    return [lower_bound, upper_bound]

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1846,6 +1846,15 @@ class ControlTheoreticAnalysisTests(unittest.TestCase):
         trial_pairs = controllers.pair_trials_by_frequency(ref_freqs, dis_freqs, max_trial_distance=2, limit_pairs_per_trial=False)
         np.testing.assert_array_equal(trial_pairs, expected_pairs)
 
+class ConfidenceIntervalTests(unittest.TestCase):
+    def test_get_confidence_interval(self):
+        np.random.seed(1)
+        uniform_random = np.random.uniform(size=10000)
+        hist_bins = np.linspace(0,1,10000)
+        interval = aopy.analysis.get_confidence_interval(uniform_random, hist_bins)
+        self.assertEqual(round(interval[0],3), 0.026)
+        self.assertEqual(round(interval[1],3), 0.975)
+        
 if __name__ == "__main__":
 
     unittest.main()

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1854,6 +1854,12 @@ class ConfidenceIntervalTests(unittest.TestCase):
         interval = aopy.analysis.get_confidence_interval(uniform_random, hist_bins)
         self.assertEqual(round(interval[0],3), 0.026)
         self.assertEqual(round(interval[1],3), 0.975)
+    
+    def test_calc_confidence_interval_overlap(self):
+        CI1 = [10,20]
+        CI2 = [17,30]
+        overlap = aopy.analysis.calc_confidence_interval_overlap(CI1,CI2)
+        self.assertEqual(overlap,(20-17)/(20-10))
         
 if __name__ == "__main__":
 


### PR DESCRIPTION
Computes a confidence interval from cdf in data samples, not a confidence interval in the mean of samples.
Computes a overlap ratio (0 to 1) between 2 confidence intervals