### PR TITLE
add metadata columns function

### DIFF
--- a/aopy/data/db.py
+++ b/aopy/data/db.py
@@ -762,7 +762,10 @@ def encode_onehot_sequence_name(sessions, sequence_types):
 def add_metadata_columns(df, sessions, column_names, apply_fns):
     '''
     Adds metadata columns (in-place) to a dataframe keyed on session id (e.g. from 
-    :func:`~aopy.data.tabulate_behavior_data`).
+    :func:`~aopy.data.tabulate_behavior_data`). Specify the same number of column names
+    as functions. Each function should take a single session as input and return a
+    single value of any type. The return value will be appended to the dataframe in all
+    rows where the task entry id (te_id) matches the input session. 
 
     Args:
         df (pd.DataFrame): dataframe of session summaries
@@ -772,13 +775,28 @@ def add_metadata_columns(df, sessions, column_names, apply_fns):
 
     Examples:
 
+        Addding a metadata column to a dataframe of session summaries
+
         .. code-block:: python
 
             date_obj = date.fromisoformat('2023-02-06')
             entries = db.lookup_sessions(date=date_obj)
             df = db.summarize_entries(entries)
-            df = db.append_metadata_columns(df, entries, 'hs_data', lambda x: x.get_task_param('record_headstage'))
+            db.append_metadata_columns(df, entries, 'hs_data', lambda x: x.get_task_param('record_headstage'))
             display(df)
+
+        Adding session and experimenter info after tabulating behavior data
+        
+        .. code-block:: python
+
+            date_obj = date.fromisoformat('2023-02-06')
+            entries = db.lookup_sessions(date=date_obj)
+            df = aopy.data.tabulate_behavior_data(entries)
+            db.append_metadata_columns(df, entries, ['session', 'experimenter'], 
+                                                    [lambda x: x.session, lambda x: x.experimenter])
+            display(df)
+
+        More information about `entries` can be found in :class:`~aopy.data.db.BMI3DTaskEntry`
     '''
     try:
         len(column_names) == len(apply_fns)

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ install_requires = [
 
 setuptools.setup(
     name="aolab-aopy",
-    version="0.8.0",
+    version="0.8.1",
     author="aoLab",
     author_email="aorsborn@uw.edu",
     description="python code repository for aoLab @UW",

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1576,5 +1576,16 @@ class DatabaseTests(unittest.TestCase):
         df = db.encode_onehot_sequence_name(sessions, sequence_types=['centerout_2D'])
         self.assertEqual(df.shape[1], 4) 
 
+    def test_add_metadata_columns(self):
+
+        sessions = db.lookup_sessions()
+        df = pd.DataFrame({
+            'te_id': [e.id for e in sessions],
+        })
+        db.add_metadata_columns(df, sessions, ['id_copy', 'test'], [lambda e: e.id, lambda e: 'test'])
+        self.assertEqual(len(df), len(sessions))
+        self.assertEqual(df['id_copy'].sum(), df['te_id'].sum())
+        self.assertTrue(all(df['test'] == 'test'))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
maybe useful utility to add one or more columns to a dataframe with metadata from task entries from the database. i envision it being used after you create a df using tabulate_behavior_data functions but want extra info about the experiment rotations, e.g.