### PR TITLE
change func optional args to remove -np.inf

### DIFF
--- a/aopy/analysis/base.py
+++ b/aopy/analysis/base.py
@@ -1437,7 +1437,7 @@ def get_tfr_feats(freqs, spec, bands, log=False, epsilon=1e-9):
 
     return np.squeeze(feats)
 
-def calc_tfr_mean(freqs, time, spec, band=(0, np.inf), window=(-np.inf, np.inf)):
+def calc_tfr_mean(freqs, time, spec, band=(0, 1e16), window=(-1e16, 1e16)):
     """
     Calculate the mean within a specific frequency band and time window.
     
@@ -1457,7 +1457,7 @@ def calc_tfr_mean(freqs, time, spec, band=(0, np.inf), window=(-np.inf, np.inf))
     
     return np.nanmean(spec[tf_idx], axis=(0, 1))
 
-def calc_tfr_mean_fdrc_ranktest(freqs, time, spec, null_specs, band=(0,np.inf), window=(-np.inf, np.inf),
+def calc_tfr_mean_fdrc_ranktest(freqs, time, spec, null_specs, band=(0,1e16), window=(-1e16, 1e16),
                                 alternative='greater', nan_policy='raise', alpha=0.05):
     """
     Compute band-specific Wilcoxon sign-rank test with false discovery-rate correction. Used for comparing 


### PR DESCRIPTION
I think the readthedocs autodoc importer doesn't like -np.inf for some reason. The long shows this:

`WARNING: autodoc: failed to import module 'analysis.base' from module 'aopy'; the following exception was raised:
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/analyze/envs/latest/lib/python3.9/site-packages/sphinx/ext/autodoc/importer.py", line 58, in import_module
    return importlib.import_module(modname)
  File "/home/docs/.asdf/installs/python/3.9.20/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/home/docs/checkouts/readthedocs.org/user_builds/analyze/checkouts/latest/aopy/__init__.py", line 3, in <module>
    from . import analysis, data, postproc, precondition, preproc, visualization, tutorial_functions, utils
  File "/home/docs/checkouts/readthedocs.org/user_builds/analyze/checkouts/latest/aopy/analysis/__init__.py", line 1, in <module>
    from .base import *
  File "/home/docs/checkouts/readthedocs.org/user_builds/analyze/checkouts/latest/aopy/analysis/base.py", line 1440, in <module>
    def calc_tfr_mean(freqs, time, spec, band=(0, np.inf), window=(-np.inf, np.inf)):
TypeError: bad operand type for unary -: 'inf'`