### PR TITLE
update python_requires to specify compatible Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,4 +47,5 @@ setuptools.setup(
         "Operating System :: OS Independent"
     ],
     install_requires=install_requires,
+    python_requires=">=3.7, <3.12",
 )


### PR DESCRIPTION
Python 3.13, the latest version, is incompatible with the numpy and spicy versions used in the aopy library. Consequently, there are installation errors encountered when attempting to locally install aopy.

For instance, when using numpy<2.0 with Python 3.13, build errors occur. Additionally, Scipy>1.13, which is compatible with Python 3.13, has deprecated a function from scipy.interpolate.interpnd import _ndim_coords_from_arrays, which is utilized in the aopy visualization library. Numpy 1.25.2 and Scipy 1.11.4 were compatible with Python 3.9 for me. 

I ran setup.py with different versions of Python between 3.7 and 3.12, and all of those installations worked while 3.13 failed. Therefore, I included a python_requires addition in setup.py. 
