### PR TITLE
check length of task and clock

### DIFF
--- a/aopy/preproc/bmi3d.py
+++ b/aopy/preproc/bmi3d.py
@@ -420,7 +420,17 @@ def _prepare_bmi3d_v0(data, metadata):
         warnings.warn("No task data found! Cannot accurately prepare bmi3d data")
         preproc_errors.append("No task data found! Cannot accurately prepare bmi3d data")
         data['task'] = np.zeros((0,), dtype=[('time', 'f8'), ('cursor', 'f8', (3,))])
-        
+    
+    # Compare task and clock data
+    if len(data['task']) < len(data['clock']):
+        warnings.warn(f"Number of task cycles ({len(data['task'])}) doesn't match number of clock cycles ({len(data['clock'])}).")
+        preproc_errors.append(f"Number of task cycles ({len(data['task'])}) doesn't match number of clock cycles ({len(data['clock'])}).")
+        data['clock'] = data['clock'][:len(data['task'])]
+    elif len(data['task']) > len(data['clock']):
+        warnings.warn(f"Number of task cycles ({len(data['task'])}) is larger than number of clock cycles ({len(data['clock'])}).")
+        preproc_errors.append(f"Number of task cycles ({len(data['task'])}) is larger than number of clock cycles ({len(data['clock'])}).")
+        data['task'] = data['task'][:len(data['clock'])]
+    
     if isinstance(data['task'], np.ndarray) and 'manual_input' in data['task'].dtype.names:
         data['clean_hand_position'] = data['task']['manual_input']
 
@@ -634,6 +644,16 @@ def _prepare_bmi3d_v1(data, metadata):
         warnings.warn("No task data found!")
         preproc_errors.append("No hdf task data found!")
         task = np.zeros((0,), dtype=[('time', 'f8'), ('cursor', 'f8', (3,))])
+
+    # Compare the task and clock data
+    if len(task) < len(corrected_clock):
+        warnings.warn(f"Number of task cycles ({len(task)}) doesn't match number of clock cycles ({len(corrected_clock)}).")
+        preproc_errors.append(f"Number of task cycles ({len(task)}) doesn't match number of clock cycles ({len(corrected_clock)}).")
+        corrected_clock = corrected_clock[:len(task)]
+    elif len(task) > len(corrected_clock):
+        warnings.warn(f"Number of task cycles ({len(task)}) is larger than number of clock cycles ({len(corrected_clock)}).")
+        preproc_errors.append(f"Number of task cycles ({len(task)}) is larger than number of clock cycles ({len(corrected_clock)}).")
+        task = task[:len(corrected_clock)]
 
     data.update({
         'task': task,


### PR DESCRIPTION
add a preprocessing check to make sure the length of the task data and clock data are the same, and truncate otherwise