### PR TITLE
katherine-update-tabulate-behavior

### DIFF
--- a/aopy/data/bmi3d.py
+++ b/aopy/data/bmi3d.py
@@ -1768,6 +1768,8 @@ def tabulate_behavior_data(preproc_dir, subjects, ids, dates, start_events, end_
 
         # Concatenate with existing dataframes
         df = pd.concat([df,pd.DataFrame(exp)], ignore_index=True)
+        df['reward'] = df['reward'].astype(bool)
+        df['penalty'] = df['penalty'].astype(bool)
     
     if return_bad_entries:
         return df, bad_entries


### PR DESCRIPTION
This ensures that reward & penalty columns are always bool, even after concatenating an empty df (which turns the reward and penalty column values in the existing df to float)