### PR TITLE
katherine-update-tabulate-kinematics

### DIFF
--- a/aopy/data/bmi3d.py
+++ b/aopy/data/bmi3d.py
@@ -3215,7 +3215,8 @@ def tabulate_kinematic_data(preproc_dir, subjects, te_ids, dates, start_times, e
         dates (list of str): Date for each recording
         start_times (list of float): times in the recording at which the desired segments starts
         end_times (list of float): times in the recording at which the desired segments ends
-        samplerate (float, optional): optionally choose the samplerate of the data in Hz. Default 1000.
+        samplerate (float or list of float, optional): samplerate of the data in Hz. 
+            Can choose to use a fixed samplerate for all segments or specify a different samplerate for each segment. Default 1000.
         datatype (str, optional): type of kinematics to tabulate. Defaults to 'cursor'.  
         deriv (int, optional): order of the derivative to compute. Default 0, no derivative.
         norm (bool, optional): if the output segments should be vector normalized at each timepoint. Default False.


### PR DESCRIPTION
One small modification to `tabulate_kinematic_data()` that allows users to input a single samplerate to get all data segments or a list of samplerates that corresponds to the number of data segments. This is helpful when segmenting a session where the bmi3d frame rate really dropped off, and so using the same "idealized" samplerate for all segments will produce some segments with too many samples (relevant for spectral analyses).