### PR TITLE
apply cond_mask to unique calculation

### DIFF
--- a/aopy/postproc/base.py
+++ b/aopy/postproc/base.py
@@ -165,7 +165,7 @@ def get_minimum_trials_per_target(target_idx, cond_mask=None):
     if cond_mask is None:
         min_trial = min([sum(target_idx == itarget) for itarget in np.unique(target_idx)])
     else:
-        min_trial = min([sum(target_idx[cond_mask] == itarget) for itarget in np.unique(target_idx)])
+        min_trial = min([sum(target_idx[cond_mask] == itarget) for itarget in np.unique(target_idx[cond_mask])])
     
     return min_trial
 


### PR DESCRIPTION
the `cond_mask` wasn't applied to the np.unique calculation in `get_minimum_trials_per_target` so the function often returns zero